### PR TITLE
fix: windows deep link[]

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3197,7 +3197,6 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "tokio-util 0.6.10",
- "winreg 0.52.0",
 ]
 
 [[package]]
@@ -4751,16 +4750,6 @@ name = "winreg"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sparrow-app"
 version = "0.0.0"
-description = "A Tauri App"
-authors = ["you"]
-license = ""
-repository = ""
+description = "Sparrow"
+authors = ["sparrow"]
+license = "https://github.com/sparrowapp-dev/sparrow-app/blob/main/LICENSE"
+repository = "https://github.com/sparrowapp-dev/sparrow-app"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -27,8 +27,6 @@ tokio-util = { version = "0.6", features = ["full"] }
 tauri-plugin-os = "2.0.0-beta.0"
 tauri-plugin-updater = "2.0.0-beta"
 tauri-plugin-process = "2.0.0-beta"
-[target.'cfg(target_os = "windows")'.dependencies]
-winreg = "0.52.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 

--- a/src-tauri/assets/DeepLinkRegistryEntries.wxs
+++ b/src-tauri/assets/DeepLinkRegistryEntries.wxs
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix
+	xmlns="http://schemas.microsoft.com/wix/2006/wi">
+	<Fragment>
+		<DirectoryRef Id="TARGETDIR">
+			<Component Id="DeepLinkRegistryEntries" Guid="24b24bc1-8389-4ac7-bde7-99f078440507">
+				<RegistryKey
+          Root="HKCR"
+          Key="sparrow\shell\open\command"
+          ForceCreateOnInstall="yes"
+          ForceDeleteOnUninstall="yes"
+        >
+					<RegistryValue
+            Type="string"
+            Value="C:\Program Files\sparrow-app\sparrow-app.exe"
+            KeyPath="yes"
+          />
+				</RegistryKey>
+				<RegistryKey 
+          Root="HKCR"
+          Key="sparrow"
+          ForceCreateOnInstall="yes"
+          ForceDeleteOnUninstall="yes"
+        >
+					<RegistryValue
+            Type="string"
+            Value="Sparrow"
+          />
+					<RegistryValue
+            Type="string"
+            Name="URL Protocol"
+            Value=""
+          />
+				</RegistryKey>
+			</Component>
+		</DirectoryRef> 
+	</Fragment>
+</Wix>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
         "minHeight": 700,
         "minWidth": 570,
         "resizable": true,
-        "title": "sparrow-app",
+        "title": "Sparrow",
         "shadow": true
       }
     ],
@@ -34,7 +34,13 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "targets": "all"
+    "targets": "all",
+    "windows": {
+      "wix": {
+        "fragmentPaths": ["./assets/DeepLinkRegistryEntries.wxs"],
+        "componentRefs": ["DeepLinkRegistryEntries"]
+      }
+    }
   },
   "identifier": "dev.sparrowapp.desktop",
   "plugins": {
@@ -50,6 +56,6 @@
       "domains": []
     }
   },
-  "productName": "sparrow-app",
+  "productName": "Sparrow",
   "version": "0.0.0"
 }


### PR DESCRIPTION
## Description

App crashing on windows after trying to set registry keys automatically on app start. This was happening due to app being run without admin privileges. 

Fix - Setting registry keys on installer level.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy
