### PR TITLE
fix: deprecate right click option on team workspaces 

### DIFF
--- a/src/lib/components/dashboard/rows/Rows.svelte
+++ b/src/lib/components/dashboard/rows/Rows.svelte
@@ -69,7 +69,7 @@
   }
 </script>
 
-{#if showMenu}
+<!-- {#if showMenu && false}
   <RightOption
     xAxis={pos.x}
     yAxis={pos.y}
@@ -77,7 +77,7 @@
     {noOfColumns}
     {menuItems}
   />
-{/if}
+{/if} -->
 
 <svelte:window
   on:click={closeRightClickContextMenu}
@@ -140,7 +140,7 @@
   >
   <td class="tab-data rounded-end py-3">
     <button
-      class="threedot-icon-container border-0 rounded d-flex justify-content-center align-items-center position-relative {showMenu
+      class="d-none threedot-icon-container border-0 rounded d-flex justify-content-center align-items-center position-relative {showMenu
         ? 'threedot-active'
         : ''}"
       on:click={(e) => {

--- a/src/lib/components/dashboard/workspace-grid/WorkspaceGrid.svelte
+++ b/src/lib/components/dashboard/workspace-grid/WorkspaceGrid.svelte
@@ -93,7 +93,7 @@
   on:click={closeRightClickContextMenu}
   on:contextmenu|preventDefault={closeRightClickContextMenu}
 />
-{#if showMenu}
+<!-- {#if showMenu}
   <RightOption
     xAxis={pos.x}
     yAxis={pos.y}
@@ -101,7 +101,7 @@
     {noOfColumns}
     {menuItems}
   />
-{/if}
+{/if} -->
 
 <div class="workspace-card-outer w-100">
   <Card
@@ -109,7 +109,7 @@
     cardStyleProp={"max-width: 47.5%; max-height: 32%;"}
   >
     <button
-      class="threedot-icon-container border-0 rounded d-flex justify-content-center align-items-center position-absolute {showMenu
+      class="d-none threedot-icon-container border-0 rounded d-flex justify-content-center align-items-center position-absolute {showMenu
         ? 'threedot-active'
         : ''}"
       style="top:15px;

--- a/src/lib/components/workspace/workspace-tab/myWorkspace.svelte
+++ b/src/lib/components/workspace/workspace-tab/myWorkspace.svelte
@@ -376,6 +376,7 @@
 
   .btn-primary {
     z-index: 5;
+    background-color: var(--primary-btn-color) !important;
   }
 
   .profile-circle {

--- a/src/lib/components/workspace/workspaceSetting.svelte
+++ b/src/lib/components/workspace/workspaceSetting.svelte
@@ -230,11 +230,11 @@
       <br />
 
       <div
-        class="d-flex align-items-center justify-content-between gap-3 mt-2 pb-3 mb-0 rounded"
+        class="d-flex align-items-center justify-content-between gap-3 mt-2 pb-3 mb-0 rounded ellipsis"
         style="font-size: 16px;"
       >
-        <div class="d-flex align-items-center">
-          <p style="font-size:16px;" class="mb-0">
+        <div class="d-flex align-items-center ellipsis">
+          <p style="font-size:16px;" class="mb-0 ellipsis">
             {currentWorkspaceDetails.name}
           </p>
         </div>


### PR DESCRIPTION
## Description
Deprecate right click option on team workspaces 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

