### PR TITLE
fix: team icon overlapped by text [610]

### DIFF
--- a/src/lib/components/inputs/SelectInput.svelte
+++ b/src/lib/components/inputs/SelectInput.svelte
@@ -95,7 +95,7 @@
                 />
               {/if}
             </div>
-            <span class="ellipsis overflow-hidden">{option.name}</span>
+            <span class="ellipsis">{option.name}</span>
           </div>
           {#if option.endIconVisible}
             <PeopleIcon color={"#45494D"} />


### PR DESCRIPTION
## Description

closes #563 
Last time, in create workspace, team icon was overlapped by text, this is fixed.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
