### PR TITLE
fix: tooltip-+collection-viewer [677]

### DIFF
--- a/src/lib/components/collections/collections-list/empty-collection/EmptyCollection.svelte
+++ b/src/lib/components/collections/collections-list/empty-collection/EmptyCollection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import whitePlus from "$lib/assets/plus-white.svg";
+  import Plus from "$lib/assets/plus.svelte";
   import { UntrackedItems } from "$lib/utils/enums/item-type.enum";
   import { moveNavigation } from "$lib/utils/helpers/navigation";
   import type { CollectionsMethods } from "$lib/utils/interfaces/collections.interface";
@@ -64,6 +65,7 @@ font-weight: 300;"
           loggedUserRoleInWorkspace,
           workspaceLevelPermissions.ADD_ENVIRONMENT,
         )}
+        placement="top"
       >
         <button
           disabled={!hasWorkpaceLevelPermission(
@@ -75,12 +77,19 @@ font-weight: 300;"
             handleImportCollectionPopup(true);
           }}
         >
-          <img src={whitePlus} alt="+" />Collection
+          <Plus
+            color={hasWorkpaceLevelPermission ? "gray" : "white"}
+            height="14"
+            width="14"
+          />Collection
         </button>
       </Tooltip>
       <Tooltip title={"API Request"} show={false}>
-        <button class="buttons w-100" on:click={addApiRequest}>
-          <img src={whitePlus} alt="+" />
+        <button
+          class="buttons w-100 d-flex mb-3 justify-content-center align-items-center gap-1"
+          on:click={addApiRequest}
+        >
+          <Plus height="14" width="14" classProp="my-auto" />
           API Request</button
         ></Tooltip
       >


### PR DESCRIPTION
## Description

closes #677, for viewer member of team, + collection tooltip should be visible and plus icon be grayish

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
