### PR TITLE
Fix/latest created environment should appear in the screen if there are multiple environment list

### DIFF
--- a/src/packages/@library/ui/list/List.svelte
+++ b/src/packages/@library/ui/list/List.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { afterUpdate } from 'svelte';
   /**
    * list height
    */
@@ -15,9 +16,18 @@
    * additional classes
    */
   export let classProps = "";
+  let listContainer;
+
+  afterUpdate(() => {
+    if (listContainer) {
+      listContainer.scrollTop = listContainer.scrollHeight; 
+    }
+  });
+
 </script>
 
 <div
+bind:this={listContainer} 
   class={`list-container gap-2 sparrow-thin-scrollbar ${classProps}`}
   style={`height: ${height}; overflow-y: ${overflowY}; overflow-x: ${overflowX};`}
 >


### PR DESCRIPTION
## Description

whenever we add more than  15 new environment the newly created environment isn't visible . In this bug fix I added scroll functionality. As soon as the new environment is created the  list scrolls down to the new environment.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
