### PR TITLE
[staging] fix : disabled right click on help page to make it consistent  [123]

### DIFF
--- a/src/packages/@app/pages/Help/HelpPage.svelte
+++ b/src/packages/@app/pages/Help/HelpPage.svelte
@@ -3,6 +3,8 @@
   import DiscordPost from "@support/features/discord-post/layout/DiscordPost.svelte";
   import HelpPageViewModel from "./HelpPage.ViewModel";
   const _viewModel = new HelpPageViewModel();
+  
+  document.addEventListener('contextmenu', event => event.preventDefault());
 </script>
 
 <div class="w-100 d-flex pt-4 jutify-content-center bg-secondary-900">


### PR DESCRIPTION
## Description

The right click functionality on other pages except the help page was disabled. Used the 'contextmenu' event listener to fix it.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
