### PR TITLE
[staging] fix: Fixed overlapping username issue [123]

### DIFF
--- a/src/packages/@common/components/sidebar/SidebarProfileModal.svelte
+++ b/src/packages/@common/components/sidebar/SidebarProfileModal.svelte
@@ -83,7 +83,7 @@
     showModal = !showModal;
   }}
 >
-  <div class="d-flex align-iems-center justify-content-center">
+  <div class="d-flex align-iems-center justify-content-center ">
     {#if isHovered && item.hoveredLogo && !item.disabled}
       <img src={item.hoveredLogo} alt={item.heading} />
     {:else if isRouteActive && item.selectedLogo}
@@ -112,9 +112,16 @@
     >
       {user?.name[0]}
     </div>
-    <div class="d-flex flex-column ms-1">
-      <div class="ellipsis">{user?.name}</div>
-      <div class="text-secondary-200 ellipsis">{user?.email}</div>
+    <div class="d-flex flex-column ms-1 ">
+      <div class="ellipsis"
+      style="max-width: 200px; ">
+        {user?.name}
+      </div>
+      <div
+      style="max-width: 200px; "
+      class="text-secondary-200 ellipsis">
+        {user?.email}
+      </div>
     </div>
   </div>
   <button


### PR DESCRIPTION
## Description

This PR solved the issue when a  user takes his/her username too long than while hovering on profile button in siderbar the UI of profile detail box expand too long .
This PR has fixed this issue by giving max-width to the container

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
