### PR TITLE
[staging] Fix: Fixed Env renaming  function call [123]

### DIFF
--- a/src/packages/@environments/features/environment-explorer/layout/EnvironmentExplorer.svelte
+++ b/src/packages/@environments/features/environment-explorer/layout/EnvironmentExplorer.svelte
@@ -63,9 +63,7 @@
             handleCurrentEnvironmentNameChange(environmentName, "");
           }}
           on:blur={(e) => {
-            if (e.target.value !== environmentName) {
-              handleCurrentEnvironmentNameChange(newValue, "blur");
-            }
+            handleCurrentEnvironmentNameChange(environmentName, "blur");
           }}
           defaultBorderColor="transparent"
           hoveredBorderColor="transparent"

--- a/src/packages/@environments/features/environment-explorer/layout/EnvironmentExplorer.svelte
+++ b/src/packages/@environments/features/environment-explorer/layout/EnvironmentExplorer.svelte
@@ -63,7 +63,9 @@
             handleCurrentEnvironmentNameChange(environmentName, "");
           }}
           on:blur={(e) => {
-            handleCurrentEnvironmentNameChange(environmentName, "blur");
+            if (e.target.value !== environmentName) {
+              handleCurrentEnvironmentNameChange(newValue, "blur");
+            }
           }}
           defaultBorderColor="transparent"
           hoveredBorderColor="transparent"

--- a/src/packages/@workspaces/features/collection-list/components/folder/Folder.svelte
+++ b/src/packages/@workspaces/features/collection-list/components/folder/Folder.svelte
@@ -385,7 +385,7 @@
                       font-weight:400;
                       margin-left:0px"
             >
-              <p class="ellipsis mb-0" style="font-size: 12px;">
+              <p class="ellipsis  mb-0" style="font-size: 12px;">
                 {explorer.name}
               </p>
             </div>
@@ -603,7 +603,7 @@
     border-radius: 2px;
   }
   .folder-title {
-    width: calc(100% - 30px);
+    width: calc(100% - 40px);
   }
   .folder-icon {
     width: 16px;


### PR DESCRIPTION
## Description

I have fixed the issue while we click on input on renaming the environment name there is on blur event call which should not be call without any change so added a if condition that is previous value is equal to current value than there should not be any function call and also i have increase the gap between the folder name and shortcut button

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
