### PR TITLE
Fix: refreshing collection count at workspace level (teams module)

### DIFF
--- a/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
+++ b/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
@@ -336,7 +336,6 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
     const response = await this.teamService.removeMembersAtTeam(
@@ -403,7 +402,6 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
     const response = await this.teamService.promoteToAdminAtTeam(
@@ -493,7 +491,6 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
     const response = await this.workspaceService.removeUserFromWorkspace(
@@ -527,7 +524,6 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
     const response = await this.workspaceService.changeUserRoleAtWorkspace(

--- a/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.svelte
+++ b/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.svelte
@@ -8,6 +8,7 @@
   import { LeaveTeam } from "@teams/features";
 
   import { DeleteWorkspace } from "@common/features";
+    import { onMount } from "svelte";
   let isDeleteWorkspaceModalOpen = false;
   let selectedWorkspace: WorkspaceDocument;
   const _viewModel = new TeamExplorerPageViewModel();
@@ -31,6 +32,11 @@
     selectedWorkspace = workspace;
     isDeleteWorkspaceModalOpen = true;
   };
+
+  onMount(()=>{
+    _viewModel.refreshTeams(userId);
+    _viewModel.refreshWorkspaces(userId);
+  });
 </script>
 
 <TeamExplorer

--- a/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
+++ b/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
@@ -252,7 +252,6 @@ export default class WorkspaceExplorerViewModel {
     if (exisitingUpdates && exisitingUpdates[0]?.updates?.length % 20 === 0) {
       const page = (parseInt(exisitingUpdates[0]?.pageNumber) + 1).toString();
       const response = await this.updatesService.getUpdates(workspaceId, page);
-      console.log("response", response);
       if (response.isSuccessful) {
         await this.updatesRepository.insertUpdates(
           response.data.data,
@@ -357,7 +356,6 @@ export default class WorkspaceExplorerViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
 
@@ -394,7 +392,6 @@ export default class WorkspaceExplorerViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      console.log("val", value);
       loggedInUserId = value._id;
     });
     const response = await this.workspaceService.changeUserRoleAtWorkspace(


### PR DESCRIPTION
## Description

This pull request addresses an issue with the collection count not being refreshed correctly at the workspace level in the Teams module. The update ensures that the collection count is accurately updated whenever collections are modified, added, or removed.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ ] 👍 yes
- [ ] 🙅 no, because I am lazy


