### PR TITLE
Feat: disable invite for user already exist in team

### DIFF
--- a/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
+++ b/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
@@ -343,7 +343,7 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.teamService.removeMembersAtTeam(
       _teamId,
@@ -375,7 +375,7 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.teamService.demoteToMemberAtTeam(
       _teamId,
@@ -409,7 +409,7 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.teamService.promoteToAdminAtTeam(
       _teamId,
@@ -498,7 +498,7 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.workspaceService.removeUserFromWorkspace(
       _workspaceId,
@@ -531,7 +531,7 @@ export class TeamExplorerPageViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.workspaceService.changeUserRoleAtWorkspace(
       _workspaceId,

--- a/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.svelte
+++ b/src/packages/@app/pages/TeamExplorerPage/TeamExplorerPage.svelte
@@ -75,6 +75,7 @@
     teamLogo={$activeTeam?.logo}
     onInviteClick={_viewModel.handleTeamInvite}
     teamName={$activeTeam?.name}
+    users={$activeTeam?.users}
     teamId={$activeTeam?.teamId}
     workspaces={$workspaces.filter((elem) => {
       return elem?.team?.teamId === $activeTeam?.teamId;
@@ -82,6 +83,7 @@
     handleModalState={(flag) => {
       isTeamInviteModalOpen = flag;
     }}
+    onValidateEmail={_viewModel.validateUserEmail}
   />
 </Modal>
 

--- a/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
+++ b/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
@@ -356,7 +356,7 @@ export default class WorkspaceExplorerViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
 
     const response = await this.workspaceService.removeUserFromWorkspace(
@@ -392,7 +392,7 @@ export default class WorkspaceExplorerViewModel {
   ) => {
     let loggedInUserId = "";
     user.subscribe((value) => {
-      loggedInUserId = value._id;
+      loggedInUserId = value?._id;
     });
     const response = await this.workspaceService.changeUserRoleAtWorkspace(
       _workspaceId,

--- a/src/packages/@app/services/user.service.ts
+++ b/src/packages/@app/services/user.service.ts
@@ -15,4 +15,21 @@ export class UserService {
     );
     return response;
   };
+
+  /**
+   * Validates the user email by making a GET request to the server.
+   *
+   * @param email - The email address to be validated.
+   * @return A promise that resolves to the server's response.
+   */
+  public validateUserEmail = async (email: string) => {
+    const response: MakeRequestResponse = await makeRequest(
+      "GET",
+      `${apiUrl}/api/user/email/${email}`,
+      {
+        headers: getAuthHeaders(),
+      },
+    );
+    return response;
+  };
 }

--- a/src/packages/@teams/features/team-invite/layout/TeamInvite.svelte
+++ b/src/packages/@teams/features/team-invite/layout/TeamInvite.svelte
@@ -54,6 +54,10 @@
     invalidEmails = invalidEmails.filter((e) => e != email);
   }
 
+  /**
+   * Checks if user already exist in team
+   * @param email - email input
+   */
   const isEmailAlreadyExistInTeam = (email: string) => {
     for (let i = 0; i < users.length; i++) {
       if (email === users[i].email) {

--- a/src/packages/@teams/features/team-invite/layout/TeamInvite.svelte
+++ b/src/packages/@teams/features/team-invite/layout/TeamInvite.svelte
@@ -15,9 +15,15 @@
   export let workspaces;
   export let teamLogo;
   export let userId;
+  export let users;
+  /**
+   * Validates the user email.
+   */
+  export let onValidateEmail;
 
   import closeIconWhite from "$lib/assets/close-icon-white.svg";
   import { MultiSelect, Select } from "@library/forms";
+  import { notifications } from "@library/ui/toast/Toast";
 
   let emailstoBeSentArr: string[] = [];
   let teamSpecificWorkspace = workspaces.map((elem) => {
@@ -48,10 +54,30 @@
     invalidEmails = invalidEmails.filter((e) => e != email);
   }
 
-  const handleEmailOnAdd = (email: string) => {
+  const isEmailAlreadyExistInTeam = (email: string) => {
+    for (let i = 0; i < users.length; i++) {
+      if (email === users[i].email) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const handleEmailOnAdd = async (email: string) => {
     email = email.replace(",", "");
     email = email.trim();
-    const isValidEmail = validateEmail(email);
+
+    const isEmailAlreadyExist = isEmailAlreadyExistInTeam(email);
+    if (isEmailAlreadyExist) {
+      notifications.error("User already in team!");
+    }
+    const isUserExist = await onValidateEmail(email); // checks if user exist on server
+    if (!isUserExist) {
+      notifications.error("User doesn't exist on sparrow!");
+    }
+    const isValidEmail =
+      validateEmail(email) && !isEmailAlreadyExist && isUserExist;
+
     if (!isValidEmail) {
       invalidEmails.push(email);
     } else {


### PR DESCRIPTION
## Description
This pull request introduces a feature to disable the invitation functionality for users who are already members of a team. This prevents sending redundant invites and improves the user experience by avoiding confusion and clutter.

Fixes #1234

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

