### PR TITLE
fix: disable quick help when no tabs are open [#1318]

### DIFF
--- a/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
+++ b/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
@@ -734,7 +734,6 @@ export default class CollectionsViewModel {
       });
       let path = {
         workspaceId: workspaceId,
-        collectionId: collectionId,
       };
       const initCollectionTab = new InitCollectionTab(
         collectionId,

--- a/src/packages/@app/pages/Collections/CollectionsPage.svelte
+++ b/src/packages/@app/pages/Collections/CollectionsPage.svelte
@@ -313,7 +313,6 @@
                   <Motion {...scaleMotionProps} let:motion>
                     <div class="h-100" use:motion>
                       <WorkspaceDefault
-                        tab={$tabList}
                         showImportCollectionPopup={() =>
                           (isImportCollectionPopup = true)}
                         onItemCreated={_viewModel.handleCreateItem}

--- a/src/packages/@workspaces/common/components/missed-environment/MissedEnvironment.svelte
+++ b/src/packages/@workspaces/common/components/missed-environment/MissedEnvironment.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { isGuestUserActive } from "$lib/store";
   import { DangerIcon } from "@library/icons";
   import { onDestroy, onMount } from "svelte";
 
@@ -25,10 +24,6 @@
    */
   export let onUpdateEnvironment;
   export let environmentVariables;
-  let isGuestUser;
-  isGuestUserActive.subscribe((value) => {
-    isGuestUser = value;
-  });
   let count = 0;
   function handleSelectClicked(event: MouseEvent) {
     const selectElement = document.getElementById(`env-not-found-${id}`);
@@ -123,9 +118,6 @@
         {/if}
         <div
           class="prevent-default text-fs-12 text-center border-radius-2 p-2 bg-primary-300"
-          style="background-color: {isGuestUser
-            ? 'var(  --bg-primary-250)'
-            : 'var(--bg-primary-300)'};"
           on:click={async (e) => {
             const response = await onUpdateEnvironment(
               isGlobalVariable,

--- a/src/packages/@workspaces/features/tab-bar/layout/TabBar.svelte
+++ b/src/packages/@workspaces/features/tab-bar/layout/TabBar.svelte
@@ -213,57 +213,53 @@
         </button>
       </Tooltip>
     </div>
-    <div class=" d-flex ms-auto my-auto me-2">
-      <!--Disabling the Quick Help feature, will be taken up in next release-->
-      {#if !isGuestUser}
-        <div>
-          <button
-            role="button"
-            class=" btn border-0 pt-1 ps-1 pe-2 py-auto h-100 w-100"
-            on:click={async () => {
-              const event = await onFetchCollectionGuide({
-                id: "collection-guide",
-              });
-              const guideData = event?.getLatest().toMutableJSON();
-              if (guideData?.isActive === false) {
-                onUpdateCollectionGuide(
-                  {
-                    id: "collection-guide",
-                  },
-                  true,
-                );
-              } else {
-                onUpdateCollectionGuide(
-                  {
-                    id: "collection-guide",
-                  },
-                  false,
-                );
-              }
-            }}
+    <div class=" d-flex ms-auto my-auto me-2 {!tabList.length ? 'd-none' : ''}">
+      <div>
+        <button
+          role="button"
+          class=" btn border-0 pt-1 ps-1 pe-2 py-auto h-100 w-100"
+          on:click={async () => {
+            const event = await onFetchCollectionGuide({
+              id: "collection-guide",
+            });
+            const guideData = event?.getLatest().toMutableJSON();
+            if (guideData?.isActive === false) {
+              onUpdateCollectionGuide(
+                {
+                  id: "collection-guide",
+                },
+                true,
+              );
+            } else {
+              onUpdateCollectionGuide(
+                {
+                  id: "collection-guide",
+                },
+                false,
+              );
+            }
+          }}
+        >
+          <Tooltip
+            title={"Quick Help"}
+            distance={10}
+            placement={"bottom"}
+            zIndex={10}
           >
-            {#if tabList.length !== 0}
-              <Tooltip
-                title={"Quick Help"}
-                distance={10}
-                placement={"bottom"}
-                zIndex={10}
-              >
-                <div
-                  class="plus-btn d-flex pt-1 pb-1 justify-content-center align-items-center"
-                  style="height: 24px; width:24px;"
-                >
-                  <HelpIcon
-                    height={"16px"}
-                    width={"16px"}
-                    color={"var(--text-secondary-200)"}
-                  />
-                </div>
-              </Tooltip>
-            {/if}
-          </button>
-        </div>
-      {/if}
+            <div
+              class="plus-btn d-flex pt-1 pb-1 justify-content-center align-items-center"
+              style="height: 24px; width:24px;"
+            >
+              <HelpIcon
+                height={"16px"}
+                width={"16px"}
+                color={"var(--text-secondary-200)"}
+              />
+            </div>
+          </Tooltip>
+        </button>
+      </div>
+
       <div class="layout ms-auto mt-1" style="height: 24px; ">
         <Dropdown
           buttonId="viewChange"


### PR DESCRIPTION
## Description

fix: disable quick help when no tabs are open #1318

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ ] 👍 yes
- [ ] 🙅 no, because I am lazy

