### PR TITLE
fix: Fixed the validation issue in mac [#1226]

### DIFF
--- a/src/packages/@teams/features/create-team/components/team-icon/TeamIcon.svelte
+++ b/src/packages/@teams/features/create-team/components/team-icon/TeamIcon.svelte
@@ -13,6 +13,8 @@
    * Types
    */
   import type { TeamForm } from "../../types";
+  import { platform } from "@tauri-apps/plugin-os";
+  import { onMount } from "svelte";
 
   /**
    * Exports
@@ -23,6 +25,12 @@
    * Data
    */
   const iconUploaderId: string = "team-file-input";
+
+  onMount(async () => {
+    os = await platform();
+  });
+
+  let os = "";
 
   /**
    * Validates the uploaded file based on size and type
@@ -70,6 +78,18 @@
     const file = targetFiles?.[0];
 
     if (!file) return;
+
+    //This need to be revisited , this is hack we are providing right now
+    
+    // Explanation :- Here this check is for mac , like the validation is missing in mac when we are uploading pdf file 
+    // so the issue there is when we are uploading the PDF file then in mac it is taking it as a jpeg file with name starts with tempImage + some randowm word 
+    // so we have wrote a check for it that if the os is macos and the file name it start with this ("tempImage")  then we are considering it as pdf file and giving the
+     // same error which we used to given when user upload pdf file 
+    if (file?.name.indexOf("tempImage") == 0 && os == "macos") {
+      teamForm.file.showFileTypeError = true;
+      teamForm.file.invalid = true;
+      return;
+    }
 
     const { size, type } = validateFile(file, maxSize, supportedFileTypes);
 


### PR DESCRIPTION
## Description

#1226 

In this PR i have fixed the valdation issue realted to uploading the team icon as pdf .
The validation is not coming in mac when we are uploading the team image as pdf and also the app is getting crashed .
So what i have done is that  first understood the issue since the code is working in  windows but not woring in mac then what i found is that when we are uploading the team logo as pdf in mac then it is taking as  jpeg format and also the name of file is changed to  "tempImage"+"some random words"   , so for now what we have done is that , we have put a check that if the  operating system is Macos and  the file that is uploading included tempImage then it show that we are trying to upload the pdf from mac so now we thrwoing the same error that comes when we upload the pdf file . 

So this is the way we have approach it for now , we have to revisit  it in future if there is some another better approach for it.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
