### PR TITLE
fix: Fixed option+l shortcut issue in mac[#1386]

### DIFF
--- a/src/packages/@workspaces/common/components/codemirror-input/sub-input/code-mirror-handler/CodeMirrorHandler.svelte
+++ b/src/packages/@workspaces/common/components/codemirror-input/sub-input/code-mirror-handler/CodeMirrorHandler.svelte
@@ -205,6 +205,7 @@
     if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       event.preventDefault();
     } else if (event.altKey && event.code === "KeyL" && id.includes("url")) {
+      event.preventDefault();
       codeMirrorView?.focus();
     }
   };


### PR DESCRIPTION
## Description
#1386 

Solved the mac issue while pressing optoin + L  in mac getting a random character so prevented it to defualt when  option +L is cliced and focus on the url input


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ ] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
