### PR TITLE
refactor: delete workspace items operations on team leave

### DIFF
--- a/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
+++ b/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
@@ -1992,14 +1992,7 @@ export default class CollectionsViewModel {
       this.collectionRepository.deleteCollection(collection.id);
       this.deleteCollectioninWorkspace(workspaceId, collection.id);
       notifications.success(`"${collection.name}" Collection deleted.`);
-      // this.removeMultipleTabs(deletedIds);
-      await this.tabRepository.removeTabsByQuery({
-        selector: {
-          "path.collectionId": collection.id,
-        },
-      });
-      ////////////////////////////////////////////////
-      // active any tab random tab here
+      this.removeMultipleTabs(deletedIds);
       MixpanelEvent(Events.DELETE_COLLECTION, {
         source: "Collection list",
       });

--- a/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
+++ b/src/packages/@app/pages/Collections/CollectionPage.ViewModel.ts
@@ -1992,7 +1992,14 @@ export default class CollectionsViewModel {
       this.collectionRepository.deleteCollection(collection.id);
       this.deleteCollectioninWorkspace(workspaceId, collection.id);
       notifications.success(`"${collection.name}" Collection deleted.`);
-      this.removeMultipleTabs(deletedIds);
+      // this.removeMultipleTabs(deletedIds);
+      await this.tabRepository.removeTabsByQuery({
+        selector: {
+          "path.collectionId": collection.id,
+        },
+      });
+      ////////////////////////////////////////////////
+      // active any tab random tab here
       MixpanelEvent(Events.DELETE_COLLECTION, {
         source: "Collection list",
       });

--- a/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
+++ b/src/packages/@app/pages/WorkspaceExplorerPage/WorkspaceExplorerPage.ViewModel.ts
@@ -5,6 +5,8 @@ import MixpanelEvent from "$lib/utils/mixpanel/MixpanelEvent";
 import { throttle } from "$lib/utils/throttle";
 import type { TeamDocument, WorkspaceDocument } from "@app/database/database";
 import type { UpdatesDocType } from "@app/models/updates.model";
+import { CollectionRepository } from "@app/repositories/collection.repository";
+import { EnvironmentRepository } from "@app/repositories/environment.repository";
 import { TabRepository } from "@app/repositories/tab.repository";
 import { TeamRepository } from "@app/repositories/team.repository";
 import { UpdatesRepository } from "@app/repositories/updates.repository";
@@ -22,6 +24,8 @@ export default class WorkspaceExplorerViewModel {
   private workspaceRepository = new WorkspaceRepository();
   private teamRepository = new TeamRepository();
   private updatesRepository = new UpdatesRepository();
+  private collectionRepository = new CollectionRepository();
+  private environmentRepository = new EnvironmentRepository();
 
   // Private Services
   private collectionService = new CollectionService();
@@ -157,7 +161,8 @@ export default class WorkspaceExplorerViewModel {
           "path.workspaceId": workspace._id,
         },
       });
-      await this.tabRepository.activateInitialTab();
+      await this.collectionRepository.removeCollections(workspace._id);
+      await this.environmentRepository.removeEnvironments(workspace._id);
       notifications.success(
         `${workspace.name} is removed from ${workspace?.team?.teamName}.`,
       );

--- a/src/packages/@app/repositories/team.repository.ts
+++ b/src/packages/@app/repositories/team.repository.ts
@@ -266,7 +266,7 @@ export class TeamRepository {
         },
       })
       .exec();
-    await this.workspaceRepository.removeWorkspaces(teamId);
+
     return await team.remove();
   };
 

--- a/src/packages/@app/repositories/workspace.repository.ts
+++ b/src/packages/@app/repositories/workspace.repository.ts
@@ -185,28 +185,13 @@ export class WorkspaceRepository {
   /**
    * remove workspaces by teamId
    */
-  public removeWorkspaces = async (teamId: string): Promise<any> => {
+  public findWorkspaceByTeamId = async (teamId: string): Promise<any> => {
     const workspaces = await RxDB.getInstance().rxdb.workspace.find({
       selector: {
         "team.teamId": teamId,
       },
     });
-    const workspaceDoc = await workspaces.exec();
-    for (let i = 0; i < workspaceDoc.length; i++) {
-      await this.collectionRepository.removeCollections(workspaceDoc[i]._id);
-      await this.environmentRepository.removeEnvironments(workspaceDoc[i]._id);
-      await this.tabRepository.removeTabsByQuery({
-        selector: {
-          "path.workspaceId": workspaceDoc[i]._id,
-        },
-      });
-
-      const tabs = await this.tabRepository.getTabDocs();
-      if (!tabs) {
-        await this.tabRepository.activateInitialTab();
-      }
-    }
-    return await workspaces.remove();
+    return await workspaces.exec();
   };
 
   /**
@@ -335,8 +320,8 @@ export class WorkspaceRepository {
         },
       })
       .exec();
-    await this.collectionRepository.removeCollections(workspaceId);
-    await this.environmentRepository.removeEnvironments(workspaceId);
+    // await this.collectionRepository.removeCollections(workspaceId);
+    // await this.environmentRepository.removeEnvironments(workspaceId);
     return await workspace.remove();
   };
   public addUserInWorkspace = async (

--- a/src/packages/@app/repositories/workspace.repository.ts
+++ b/src/packages/@app/repositories/workspace.repository.ts
@@ -320,8 +320,6 @@ export class WorkspaceRepository {
         },
       })
       .exec();
-    // await this.collectionRepository.removeCollections(workspaceId);
-    // await this.environmentRepository.removeEnvironments(workspaceId);
     return await workspace.remove();
   };
   public addUserInWorkspace = async (

--- a/src/packages/@app/services/team.service.ts
+++ b/src/packages/@app/services/team.service.ts
@@ -49,9 +49,6 @@ export class TeamService {
         headers: getAuthHeaders(),
       },
     );
-    if (response.isSuccessful) {
-      await this.teamRepository.removeTeam(teamId);
-    }
     return response;
   };
 
@@ -100,7 +97,7 @@ export class TeamService {
         headers: getAuthHeaders(),
       },
     );
-       return response;
+    return response;
   };
 
   public promoteToOwnerAtTeam = async (teamId: string, userId: string) => {


### PR DESCRIPTION
## Description
This PR refactors the logic that handles the deletion of workspace items when a team member leaves. The goal is to remove functions coupling through multiple repositories.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy


