### PR TITLE
feat: Cancel request midway

### DIFF
--- a/src/packages/@app/pages/RestExplorer/RestExplorerPage.svelte
+++ b/src/packages/@app/pages/RestExplorer/RestExplorerPage.svelte
@@ -144,6 +144,7 @@
   {isGuestUser}
   {isLoginBannerActive}
   onSendRequest={_viewModel.sendRequest}
+  onCancelRequest={_viewModel.cancelRequest}
   onUpdateRequestUrl={_viewModel.updateRequestUrl}
   onUpdateRequestMethod={_viewModel.updateRequestMethod}
   onUpdateRequestParams={_viewModel.updateParams}

--- a/src/packages/@deprecate/api/api.common.ts
+++ b/src/packages/@deprecate/api/api.common.ts
@@ -460,73 +460,56 @@ const makeHttpRequestV2 = async (
   headers: string,
   body: string,
   request: string,
+  signal: AbortSignal,
 ) => {
-  // create a race condition between the timeout and the api call
   console.table({ url, method, headers, body, request });
   const startTime = performance.now();
-  return Promise.race([
-    timeout(apiTimeOut),
-    // Invoke communication
-    invoke("make_http_request_v2", {
+
+  try {
+    const data = await invoke("make_http_request_v2", {
       url,
       method,
       headers,
       body,
       request,
-    }),
-  ])
-    .then(async (data: string) => {
-      const endTime = performance.now();
-      const duration = endTime - startTime;
-      try {
-        const responseBody = JSON.parse(data);
-        const apiResponse: Response = JSON.parse(responseBody.body) as Response;
-        console.table(apiResponse);
-        appInsights.trackDependencyData({
-          id: uuidv4(),
-          name: "RPC Duration Metric",
-          duration,
-          success: true,
-          responseCode: parseInt(apiResponse.status),
-          properties: {
-            source: "frontend",
-            type: "RPC_HTTP",
-          },
-        });
-        return success(apiResponse);
-      } catch (e) {
-        console.error(e);
-        appInsights.trackDependencyData({
-          id: uuidv4(),
-          name: "RPC Duration Metric",
-          duration,
-          success: false,
-          responseCode: 400,
-          properties: {
-            source: "frontend",
-            type: "RPC_HTTP",
-          },
-        });
-        return error("error");
-      }
-    })
-    .catch((e) => {
-      const endTime = performance.now();
-      const duration = endTime - startTime;
+    });
+
+    // Handle the response and update UI accordingly
+    if (signal.aborted) {
+      throw new Error(); // Ignore response if request was cancelled
+    }
+
+    const endTime = performance.now();
+    const duration = endTime - startTime;
+
+    try {
+      const responseBody = JSON.parse(data);
+      const apiResponse: Response = JSON.parse(responseBody.body) as Response;
+      console.table(apiResponse);
+
       appInsights.trackDependencyData({
         id: uuidv4(),
         name: "RPC Duration Metric",
         duration,
-        success: false,
-        responseCode: 400,
+        success: true,
+        responseCode: parseInt(apiResponse.status),
         properties: {
           source: "frontend",
           type: "RPC_HTTP",
         },
       });
+      return success(apiResponse);
+    } catch (e) {
       console.error(e);
-      return error("error");
-    });
+      throw new Error("Error parsing response");
+    }
+  } catch (e) {
+    if (signal.aborted) {
+      throw new DOMException("Request was aborted", "AbortError");
+    }
+    console.error(e);
+    throw new Error("Error with the request");
+  }
 };
 
 export {

--- a/src/packages/@deprecate/api/api.common.ts
+++ b/src/packages/@deprecate/api/api.common.ts
@@ -486,18 +486,28 @@ const makeHttpRequestV2 = async (
       const responseBody = JSON.parse(data);
       const apiResponse: Response = JSON.parse(responseBody.body) as Response;
       console.table(apiResponse);
+      let apiStatus = "400";
+      if (
+        typeof apiResponse.status === "string" &&
+        apiResponse.status.length > 0
+      ) {
+        apiStatus = apiResponse.status.split(" ")[0];
+      } else {
+        console.error("Invalid or missing status");
+      }
 
-      appInsights.trackDependencyData({
+      const appInsightData = {
         id: uuidv4(),
         name: "RPC Duration Metric",
         duration,
-        success: true,
-        responseCode: parseInt(apiResponse.status),
+        success: parseInt(apiStatus) === 200 ? true : false,
+        responseCode: parseInt(apiStatus),
         properties: {
           source: "frontend",
           type: "RPC_HTTP",
         },
-      });
+      };
+      appInsights.trackDependencyData(appInsightData);
       return success(apiResponse);
     } catch (e) {
       console.error(e);

--- a/src/packages/@workspaces/common/type/actions.ts
+++ b/src/packages/@workspaces/common/type/actions.ts
@@ -69,6 +69,8 @@ export interface ClearResponse {
   clearResponse: ClearResponseType;
 }
 export type SendRequestType = () => Promise<void>;
+
+export type CancelRequestType = () => Promise<void>;
 export interface SendRequest {
   sendRequest: SendRequestType;
 }

--- a/src/packages/@workspaces/features/rest-explorer/components/http-url-section/HttpUrlSection.svelte
+++ b/src/packages/@workspaces/features/rest-explorer/components/http-url-section/HttpUrlSection.svelte
@@ -14,6 +14,7 @@
   import { UrlInputTheme } from "../../../../common/utils/";
   import Tooltip from "@library/ui/tooltip/Tooltip.svelte";
   import { DiskIcon } from "@library/icons";
+  import type { CancelRequestType } from "@workspaces/common/type/actions";
   let componentClass = "";
   export { componentClass as class };
 
@@ -21,6 +22,7 @@
   export let httpMethod: string;
   export let isSendRequestInProgress: boolean;
   export let onSendButtonClicked: SendRequestType;
+  export let onCancelButtonClicked: CancelRequestType;
   export let onUpdateRequestUrl: UpdateRequestUrlType;
   export let onUpdateRequestMethod: UpdateRequestMethodType;
   export let toggleSaveRequest: (flag: boolean) => void;
@@ -143,6 +145,7 @@
 
   <!-- Send button -->
   <span class="ps-2"></span>
+  {#if !isSendRequestInProgress}
   <DropButton
     title="Send"
     type="default"
@@ -160,6 +163,16 @@
       }
     }}
   />
+  {:else}
+  <DropButton
+  title="Cancel"
+  type="default"
+  disable={!isSendRequestInProgress ? true : false}
+  onClick={() => {
+      onCancelButtonClicked();
+  }}
+/>
+  {/if}
 
   <!-- Switch pane layout button -->
   <!-- <ToggleButton

--- a/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
+++ b/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
@@ -359,7 +359,7 @@
                     {:else if !$tab.property.request?.response?.status}
                       <ResponseDefaultScreen />
                     {:else if $tab.property.request?.response?.status === ResponseStatusCode.ERROR}
-                      <ResponseErrorScreen />
+                      <!-- <ResponseErrorScreen /> -->
                     {:else if $tab.property.request?.response?.status}
                       <div class="h-100 d-flex flex-column">
                         <ResponseStatus

--- a/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
+++ b/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
@@ -359,7 +359,7 @@
                     {:else if !$tab.property.request?.response?.status}
                       <ResponseDefaultScreen />
                     {:else if $tab.property.request?.response?.status === ResponseStatusCode.ERROR}
-                      <!-- <ResponseErrorScreen /> -->
+                      <ResponseErrorScreen />
                     {:else if $tab.property.request?.response?.status}
                       <div class="h-100 d-flex flex-column">
                         <ResponseStatus

--- a/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
+++ b/src/packages/@workspaces/features/rest-explorer/layout/RestExplorer.svelte
@@ -67,6 +67,7 @@
     SendingApiRequest,
   } from "@workspaces/common/constants";
   import { ResponseStatusCode } from "$lib/utils/enums";
+  import type { CancelRequestType } from "@workspaces/common/type/actions";
 
   export let tab: Observable<RequestTab>;
   export let collections: Observable<CollectionDocument[]>;
@@ -74,6 +75,7 @@
   export let requestAuthParameter: Observable<KeyValue>;
   export let onUpdateRequestUrl: UpdateRequestUrlType;
   export let onSendRequest: SendRequestType;
+  export let onCancelRequest: CancelRequestType;
   export let onUpdateRequestMethod: UpdateRequestMethodType;
   export let onUpdateRequestParams: UpdateParamsType;
   export let onUpdateRequestName: UpdateRequestNameType;
@@ -192,6 +194,7 @@
         isSendRequestInProgress={$tab.property.request?.state
           ?.isSendRequestInProgress}
         onSendButtonClicked={onSendRequest}
+        onCancelButtonClicked={onCancelRequest}
         {onUpdateEnvironment}
         {environmentVariables}
         {onUpdateRequestUrl}
@@ -356,7 +359,7 @@
                     {:else if !$tab.property.request?.response?.status}
                       <ResponseDefaultScreen />
                     {:else if $tab.property.request?.response?.status === ResponseStatusCode.ERROR}
-                      <ResponseErrorScreen />
+                      <!-- <ResponseErrorScreen /> -->
                     {:else if $tab.property.request?.response?.status}
                       <div class="h-100 d-flex flex-column">
                         <ResponseStatus


### PR DESCRIPTION
## Description

A cancel button will appear once request is initiated before the response appears to cancel the ongoing request.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
Request cancels just on the UI while it continues to execute in the background, this happens since it is a RPC call and not a JS call. This is not a blocker and can be taken up as a enhancement in a future iteration.

## Related Story, task & Documents?
