### PR TITLE
fix: delay web app render by 2 sec on load to fetch essential app data

### DIFF
--- a/apps/@sparrow-web/index.html
+++ b/apps/@sparrow-web/index.html
@@ -18,9 +18,6 @@
     />
     <style>
       /* Style for the loader */
-      body {
-        background-color: rgb(16, 16, 16);
-      }
       #init-loader {
         position: fixed;
         left: 0;
@@ -31,6 +28,7 @@
         align-items: center;
         justify-content: center;
         transition: 0.3s ease;
+        background-color: rgb(16, 16, 16);
       }
 
       /* Style to hide loader when the page is fully loaded */
@@ -56,7 +54,10 @@
     <script>
       // Hide the loader after the window is fully loaded
       window.addEventListener("load", function () {
-        document.body.classList.add("loaded");
+        setTimeout(() => {
+          // delay web app render by 2 sec on load to fetch essential app data
+          document.body.classList.add("loaded");
+        }, 2000);
       });
     </script>
     <div id="init-loader">
@@ -67,7 +68,17 @@
           style="width: 20px; height: 20px"
           alt="spinner"
         />
-        <p style="margin: 0 8px">Sparrow Web Loading...</p>
+        <p
+          style="
+            margin: 0 8px;
+            font-family:
+              Times New Roman,
+              Times,
+              serif !important;
+          "
+        >
+          Sparrow Web Loading...
+        </p>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Description
This update introduces a 2-second delay before rendering the web application on initial load. The delay is intended to ensure that essential application data is fetched and available before the UI is displayed, enhancing user experience by providing a fully prepared state on render.
#1959 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy