### PR TITLE
fix: Fixed Role field dropdown width

### DIFF
--- a/packages/@sparrow-teams/src/features/team-invite/layout/TeamInvite.svelte
+++ b/packages/@sparrow-teams/src/features/team-invite/layout/TeamInvite.svelte
@@ -314,6 +314,7 @@
     borderRounded={"4px"}
     headerFontWeight={400}
     headerFontSize={"12px"}
+    flex-grow="{1};"
     isError={roleError && selectedRole === defaultRole}
   />
 </div>


### PR DESCRIPTION
## Description

I made the Select for the role field flex-grow:1, to fill the screen just like the email input above.

Please do not leave this blank 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ ] 👍 yes
- [x] 🙅 no, because I am lazy


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
@Abhishek9503 I didn't test locally because I couldn't setup properly.
I would like some help with that so I can contribute more efficiently further.
## Related Story, task & Documents?
Story #2099 Task -> #2100 
