### PR TITLE
fix: mac dmg installer alignment

### DIFF
--- a/apps/@sparrow-desktop/src-tauri/tauri.conf.json
+++ b/apps/@sparrow-desktop/src-tauri/tauri.conf.json
@@ -71,7 +71,7 @@
         },
         "windowSize": {
           "height": 500,
-          "width": 700
+          "width": 770
         },
         "windowPosition": {
           "x": 400,


### PR DESCRIPTION
## Description

This fixes the dmg installer size to rectify icon alignment issue in mac.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
