### PR TITLE
fix: updated UI image of sparrow edge in Teams

### DIFF
--- a/packages/@sparrow-teams/src/features/team-explorer/components/workspace-grid-view/WorkspaceGridView.svelte
+++ b/packages/@sparrow-teams/src/features/team-explorer/components/workspace-grid-view/WorkspaceGridView.svelte
@@ -176,8 +176,8 @@
       <img
         src={TeamSkeleton}
         alt="Team-Skelton"
-        width="96%"
-        height="90%"
+        width="100%"
+        height="100%"
         style="padding-bottom:100px;"
       />
     {/if}


### PR DESCRIPTION
## Description

I have updated image size according to the Figma [#2364].
Please do not leave this blank 
## What type of PR is this? (check all applicable)
- [x] 🐛 Bug Fix

## Have you tested locally?
- [x] 👍 yes
