### PR TITLE
feat: Run button icon and text is not properly aligned in webapp #2418

### DIFF
--- a/packages/@sparrow-workspaces/src/components/drop-button/DropButton.svelte
+++ b/packages/@sparrow-workspaces/src/components/drop-button/DropButton.svelte
@@ -45,11 +45,9 @@
   class={`border-0`}
   style="background-color: transparent; {componentStyle}"
 >
-  <div
-    class="d-flex justify-content-center h-100 border-radius-2 overflow-hidden"
-  >
+  <div class="d-flex justify-item-center h-100 border-radius-2 overflow-hidden">
     <button
-      class="main-body py-1 px-3 h-100 border-0 {btnClass}"
+      class="main-body d-flex align-items-center justify-content-space-between py-1 px-3 h-100 border-0 {btnClass} "
       on:click={(e) => {
         if (!disable) {
           onClick(e);
@@ -62,7 +60,7 @@
         </span>
       {:else if !loader}
         {#if iconRequired}
-          <span
+          <span class="d-flex me-2"
             ><Icon
               height={iconHeight}
               width={iconWidth}


### PR DESCRIPTION
## Description

Run button icon and text is not properly aligned in webapp #2418
1.Open webapp
2.Go to test flow
3.Add block in it

Expected-
Run button and logo should be properly aligned

Actual-
It is not properly aligned

![image](https://github.com/user-attachments/assets/6e716dc2-1696-4d61-a0d6-60c739b8d42f)

after changes the drop-button code we get 
![image](https://github.com/user-attachments/assets/f89b7bc1-86eb-44e3-bdc9-a52af85955f3)
