### PR TITLE
feat: Run button icon and text is not properly aligned in webapp #2418

### DIFF
--- a/packages/@sparrow-workspaces/src/components/drop-button/DropButton.svelte
+++ b/packages/@sparrow-workspaces/src/components/drop-button/DropButton.svelte
@@ -46,10 +46,10 @@
   style="background-color: transparent; {componentStyle}"
 >
   <div
-    class="d-flex justify-content-center h-100 border-radius-2 overflow-hidden"
+    class="d-flex justify-item-center h-100 border-radius-2 overflow-hidden"
   >
     <button
-      class="main-body py-1 px-3 h-100 border-0 {btnClass}"
+      class="main-body d-flex align-items-center justify-content-space-between py-1 px-3 h-100 border-0 {btnClass} "
       on:click={(e) => {
         if (!disable) {
           onClick(e);
@@ -62,7 +62,7 @@
         </span>
       {:else if !loader}
         {#if iconRequired}
-          <span
+          <span  class="d-flex me-2"
             ><Icon
               height={iconHeight}
               width={iconWidth}


### PR DESCRIPTION
Run button icon and text is not properly aligned in webapp
[#2418](https://github.com/sparrowapp-dev/sparrow-app/issues/2418)
1.Open webapp
2.Go to test flow
3.Add block in it

Expected-
Run button and logo should be properly aligned

Actual-
It is not properly aligned
![image](https://github.com/user-attachments/assets/109d9288-4b8b-4d68-81fb-5bd5f5b30882)

after changes the drop-button code we get
![image](https://github.com/user-attachments/assets/18a969dc-fe5f-4981-b1ea-ea49de767abc)
