### PR TITLE
feat: Ui Web Issue fix the aligment of the search icon and it's text

### DIFF
--- a/packages/@sparrow-library/src/assets/search.svelte
+++ b/packages/@sparrow-library/src/assets/search.svelte
@@ -5,6 +5,7 @@
 </script>
 
 <svg
+  display="flex"
   {width}
   {height}
   viewBox="0 0 16 16"


### PR DESCRIPTION
UI issue in webapp
[#2345](https://github.com/sparrowapp-dev/sparrow-app/issues/2345)

Bug1.
Search icon alignment is not proper
Expected-
Search icon alignment and placeholder should be properly aligned
Actual-
Icon and alignment are not looking proper
![image](https://github.com/user-attachments/assets/9d42216b-9a42-47d5-8510-c1e82c53dfad)


Bug 2
Quick help icon is looking smaller
Expected-
It should be as per figma
Actual-
Icon is lookin smaller
![image](https://github.com/user-attachments/assets/ddcde02e-eef3-4524-9f23-ff1379a5aa77)

after solving bug 
![image](https://github.com/user-attachments/assets/b675bdd8-e41e-4fde-b75b-578470cfdd2d)
