### PR TITLE
increased bandwidth of loading feedbacks, 

### DIFF
--- a/packages/@sparrow-support/src/features/feedback-section/layout/FeedbackSection.svelte
+++ b/packages/@sparrow-support/src/features/feedback-section/layout/FeedbackSection.svelte
@@ -284,8 +284,8 @@
   // Event handler for scrolling
   const handleScroll = async () => {
     const { scrollTop, scrollHeight, clientHeight } = scrollableContainer;
-
-    if (scrollTop + clientHeight >= scrollHeight - 100) {
+  
+    if (scrollTop + clientHeight >= scrollHeight - 3000) {
       if (!isPostFetching) {
         isPostFetching = true;
         await loadMoreUpdates();

--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/components/request-body/sub-body/request-body-navigator/RequestBodyNavigator.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/components/request-body/sub-body/request-body-navigator/RequestBodyNavigator.svelte
@@ -32,7 +32,7 @@
         >For GET requests, it's uncommon to use a request body. Some frameworks
         support the request body for GET method, but it is generally not
         recommended to use.</small
-      >
+      >y
       <div
         class="cross-button d-flex align-items-center justify-content-center"
       >


### PR DESCRIPTION
## Description
more posts were loading at end of scroller so chnages it to a little above when the user is at end of current feedbacks
Please do not leave this blank 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ x] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [ x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md

## Any Known issue?
## Related Story, task & Documents?
