### PR TITLE
fix : API Request Count

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
@@ -346,17 +346,39 @@ class CollectionExplorerPage {
     ).getFullYear()}`;
     let totalRequests = 0;
     let totalFolders = 0;
+    let totalWebSocket = 0;
+    let totalSocketIo =0 ;
+    let totalGraphQl =0;
+
     if (collection?.items) {
       collection?.items.forEach((collectionItem: CollectionItemsDto) => {
         if (collectionItem.type === ItemType.REQUEST) {
           totalRequests++;
-        } else if (collectionItem.type === ItemType.FOLDER) {
+        }
+        else if(collectionItem.type === ItemType.WEB_SOCKET) {
+            totalWebSocket++;
+         }
+        else if(collectionItem.type === ItemType.SOCKET_IO){
+            totalSocketIo++;
+        } 
+        else if(collectionItem.type === ItemType.GRAPHQL){
+          totalGraphQl++;
+        }
+          else if (collectionItem.type === ItemType.FOLDER) {
           totalFolders++;
           if (collectionItem?.items)
             collectionItem.items.forEach((item: CollectionItemsDto) => {
               if (item.type === ItemType.REQUEST) {
                 totalRequests++;
               }
+              else if(item.type === ItemType.WEB_SOCKET){
+                totalWebSocket++;
+              }
+              else if(item.type === ItemType.SOCKET_IO){
+                totalSocketIo++;
+              }else if(item.type === ItemType.GRAPHQL){
+                totalGraphQl++;
+              }      
             });
         }
       });
@@ -387,8 +409,11 @@ class CollectionExplorerPage {
     // }
     return {
       isSynced,
-      totalFolders,
       totalRequests,
+      totalSocketIo,
+      totalWebSocket,
+      totalGraphQl,
+      totalFolders,
       lastUpdated,
     };
   };

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.svelte
@@ -64,6 +64,7 @@
 
 <CollectionExplorer
   {userRole}
+  isWebApp={false}
   bind:tab
   bind:collection
   onUpdateDescription={_viewModel.handleUpdateDescription}

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
@@ -367,15 +367,29 @@ class FolderExplorerPage {
     tab: TabDocument,
   ) => {
     let totalRequests = 0;
+    let totalWebSocket =0;
+    let totalGraphQl =0; 
+    let totalSocketIo =0;
     const folder = await this.getFolder(collection, tab.id);
     if (folder?.items) {
       folder.items.forEach((item: CollectionItemsDto) => {
         if (item.type === ItemType.REQUEST) {
           totalRequests++;
+        }else if(item.type === ItemType.SOCKET_IO){
+          totalSocketIo++;
+        }else if(item.type === ItemType.GRAPHQL){
+          totalGraphQl++;
+        }else if(item.type === ItemType.WEB_SOCKET){
+          totalWebSocket++;
         }
       });
     }
-    return totalRequests;
+    return {
+      totalRequests,
+      totalGraphQl,
+      totalSocketIo,
+      totalWebSocket
+    }
   };
 
   /**

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.svelte
@@ -62,6 +62,7 @@
 </script>
 
 <FolderExplorer
+  isWebApp={false}
   bind:userRole
   bind:tab
   bind:folder

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
@@ -346,17 +346,39 @@ class CollectionExplorerPage {
     ).getFullYear()}`;
     let totalRequests = 0;
     let totalFolders = 0;
+    let totalWebSocket = 0;
+    let totalSocketIo =0 ;
+    let totalGraphQl =0;
+
     if (collection?.items) {
       collection?.items.forEach((collectionItem: CollectionItemsDto) => {
         if (collectionItem.type === ItemType.REQUEST) {
           totalRequests++;
-        } else if (collectionItem.type === ItemType.FOLDER) {
+        }
+        else if(collectionItem.type === ItemType.WEB_SOCKET) {
+            totalWebSocket++;
+         }
+        else if(collectionItem.type === ItemType.SOCKET_IO){
+            totalSocketIo++;
+        } 
+        else if(collectionItem.type === ItemType.GRAPHQL){
+          totalGraphQl++;
+        }
+          else if (collectionItem.type === ItemType.FOLDER) {
           totalFolders++;
           if (collectionItem?.items)
             collectionItem.items.forEach((item: CollectionItemsDto) => {
               if (item.type === ItemType.REQUEST) {
                 totalRequests++;
               }
+              else if(item.type === ItemType.WEB_SOCKET){
+                totalWebSocket++;
+              }
+              else if(item.type === ItemType.SOCKET_IO){
+                totalSocketIo++;
+              }else if(item.type === ItemType.GRAPHQL){
+                totalGraphQl++;
+              }    
             });
         }
       });
@@ -388,7 +410,10 @@ class CollectionExplorerPage {
     return {
       isSynced,
       totalFolders,
+      totalWebSocket,
+      totalSocketIo,
       totalRequests,
+      totalGraphQl,
       lastUpdated,
     };
   };

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.svelte
@@ -64,6 +64,7 @@
 
 <CollectionExplorer
   {userRole}
+  isWebApp={true}
   bind:tab
   bind:collection
   onUpdateDescription={_viewModel.handleUpdateDescription}

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
@@ -367,15 +367,29 @@ class FolderExplorerPage {
     tab: TabDocument,
   ) => {
     let totalRequests = 0;
+    let totalWebSocket =0;
+    let totalGraphQl =0; 
+    let totalSocketIo =0;
     const folder = await this.getFolder(collection, tab.id);
     if (folder?.items) {
       folder.items.forEach((item: CollectionItemsDto) => {
         if (item.type === ItemType.REQUEST) {
           totalRequests++;
+        }else if(item.type === ItemType.SOCKET_IO){
+          totalSocketIo++;
+        }else if(item.type === ItemType.GRAPHQL){
+          totalGraphQl++;
+        }else if(item.type === ItemType.WEB_SOCKET){
+          totalWebSocket++;
         }
       });
     }
-    return totalRequests;
+    return {
+      totalGraphQl,
+      totalRequests,
+      totalSocketIo,
+      totalWebSocket
+    }
   };
 
   /**

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.svelte
@@ -62,6 +62,7 @@
 </script>
 
 <FolderExplorer
+  isWebApp={true}
   bind:userRole
   bind:tab
   bind:folder

--- a/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
@@ -25,6 +25,9 @@
     totalFolders: number;
     totalRequests: number;
     lastUpdated: string;
+    totalWebSocket: number;
+    totalSocketIo: number;
+    totalGraphQl: number;
   }>;
   /**
    * Callback to refetch collection from local
@@ -36,6 +39,7 @@
   export let onBranchChanged: (
     collection: CollectionDocument,
     newBranch: string,
+    c,
   ) => void;
   /**
    * Callback to rename collection
@@ -79,6 +83,7 @@
    * Role of user in active workspace
    */
   export let userRole;
+  export let isWebApp = false;
 
   /**
    * Local variables
@@ -91,17 +96,24 @@
   let lastUpdated: string = "";
   let totalFolders: number = 0;
   let totalRequests: number = 0;
+  let totalWebSocket: number = 0;
+  let totalSocketIo: number = 0;
+  let totalGraphQl: number = 0;
 
   /**
    * Function to update isSynced, totalRequests and totalFolders, and lastUpdated
    */
   const updateLastUpdateAndCount = async () => {
     const res = await getLastUpdatedAndCount(collection);
+
     if (res) {
       isSynced = res.isSynced;
       lastUpdated = res.lastUpdated;
       totalFolders = res.totalFolders;
       totalRequests = res.totalRequests;
+      totalWebSocket = res.totalWebSocket;
+      totalSocketIo = res.totalSocketIo;
+      totalGraphQl = res.totalGraphQl;
     }
   };
 
@@ -387,12 +399,28 @@
     >
       <div class="d-flex gap-4 mb-4 ps-2">
         <div class="d-flex align-items-center gap-2">
-          <span class="fs-4 highlighted-number">{totalRequests}</span>
-          <p style="font-size: 12px;" class="mb-0">API Requests</p>
+          <span class="fs-4 highlighted-number">{totalFolders}</span>
+          <p style="font-size: 12px;" class="mb-0">Folders</p>
         </div>
         <div class="d-flex align-items-center gap-2">
-          <span class="fs-4 highlighted-number">{totalFolders}</span>
-          <p style="font-size: 12px;" class="mb-0">Folder</p>
+          <span class="fs-4 highlighted-number">{totalRequests}</span>
+          <p style="font-size: 12px;" class="mb-0">REST</p>
+        </div>
+        {#if !isWebApp}
+          <div>
+            <div class="d-flex align-items-center gap-2">
+              <span class="fs-4 highlighted-number">{totalGraphQl}</span>
+              <p style="font-size: 12px;" class="mb-0">GraphQL</p>
+            </div>
+          </div>
+        {/if}
+        <div class="d-flex align-items-center gap-2">
+          <span class="fs-4 highlighted-number">{totalWebSocket}</span>
+          <p style="font-size: 12px;" class="mb-0">WebSocket</p>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+          <span class="fs-4 highlighted-number">{totalSocketIo}</span>
+          <p style="font-size: 12px;" class="mb-0">Socket.IO</p>
         </div>
       </div>
       <div class="d-flex align-items-start ps-0 h-100">

--- a/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
@@ -39,7 +39,6 @@
   export let onBranchChanged: (
     collection: CollectionDocument,
     newBranch: string,
-    c,
   ) => void;
   /**
    * Callback to rename collection

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/collection/Collection.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/collection/Collection.svelte
@@ -57,6 +57,9 @@
   let deletedIds: [string] | [] = [];
   let requestCount = 0;
   let folderCount = 0;
+  let graphQLCount = 0;
+  let webSocketCount = 0;
+  let socketIoCount = 0;
   let visibility = false;
   let isActiveSyncEnabled = true;
   let isBranchSynced: boolean = false;
@@ -140,16 +143,40 @@
       deletedIds = [];
       requestCount = 0;
       folderCount = 0;
+      graphQLCount = 0;
+      webSocketCount = 0;
+      socketIoCount = 0;
       collection?.items?.forEach((item: any) => {
         if (item.type === ItemType.FOLDER) {
           deletedIds.push(item.id);
           folderCount++;
-          requestCount += item.items.length;
+
           for (let i = 0; i < item.items.length; i++) {
-            deletedIds.push(item.items[i].id);
+            if (item.items[i].type === ItemType.REQUEST) {
+              requestCount++;
+              deletedIds.push(item.items[i].id);
+            } else if (item.items[i].type === ItemType.GRAPHQL) {
+              graphQLCount++;
+              deletedIds.push(item.items[i].id);
+            } else if (item.items[i].type === ItemType.WEB_SOCKET) {
+              webSocketCount++;
+              deletedIds.push(item.items[i].id);
+            } else if (item.items[i].type === ItemType.SOCKET_IO) {
+              socketIoCount++;
+              deletedIds.push(item.items[i].id);
+            }
           }
         } else if (item.type === ItemType.REQUEST) {
           requestCount++;
+          deletedIds.push(item.id);
+        } else if (item.type === ItemType.GRAPHQL) {
+          graphQLCount++;
+          deletedIds.push(item.id);
+        } else if (item.type === ItemType.SOCKET_IO) {
+          socketIoCount++;
+          deletedIds.push(item.id);
+        } else if (item.type === ItemType.WEB_SOCKET) {
+          webSocketCount++;
           deletedIds.push(item.id);
         }
       });
@@ -250,12 +277,26 @@
   </div>
   <div class="d-flex gap-3 sparrow-fs-12">
     <div class="d-flex gap-1">
-      <span class="text-plusButton">{requestCount}</span>
-      <p>API Requests</p>
-    </div>
-    <div class="d-flex gap-1">
       <span class="text-plusButton">{folderCount}</span>
       <p>Folder</p>
+    </div>
+    <div class="d-flex gap-1">
+      <span class="text-plusButton">{requestCount}</span>
+      <p>REST</p>
+    </div>
+    {#if !isWebApp}
+      <div class="d-flex gap-1">
+        <span class="text-plusButton">{graphQLCount}</span>
+        <p>GraphQL</p>
+      </div>
+    {/if}
+    <div class="d-flex gap-1">
+      <span class="text-plusButton">{webSocketCount}</span>
+      <p>WebSocket</p>
+    </div>
+    <div class="d-flex gap-1">
+      <span class="text-plusButton">{socketIoCount}</span>
+      <p>Socket.IO</p>
     </div>
   </div>
   <div

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
@@ -97,6 +97,9 @@
   let noOfColumns = 180;
   let isRenaming = false;
   let requestCount: number;
+  let graghQlCount: number;
+  let webSocketCount: number;
+  let socketIoCount: number;
   let requestIds: [string] | [] = [];
   let folderTabWrapper: HTMLElement;
 
@@ -112,13 +115,27 @@
     if (explorer) {
       requestIds = [];
       requestCount = 0;
-      requestCount = explorer?.items?.length;
-      if (explorer?.items) {
-        requestIds = explorer?.items?.map((element: { id: any }) => {
-          return element.id;
+      graghQlCount = 0;
+      socketIoCount = 0;
+      webSocketCount = 0;
+
+      if (explorer.items) {
+        explorer.items.forEach((item: any) => {
+          if (item.type === ItemType.REQUEST) {
+            requestCount++;
+            requestIds.push(item.id);
+          } else if (item.type === ItemType.GRAPHQL) {
+            graphQLCount++;
+            requestIds.push(item.id);
+          } else if (item.type === ItemType.WEB_SOCKET) {
+            webSocketCount++;
+            requestIds.push(item.id);
+          } else if (item.type === ItemType.SOCKET_IO) {
+            socketIoCount++;
+            requestIds.push(item.id);
+          }
         });
       }
-      requestIds.push(explorer?.id);
     }
   }
 
@@ -203,7 +220,21 @@
     <div class="d-flex gap-3 sparrow-fs-12">
       <div class="d-flex gap-1">
         <span class="text-plusButton">{requestCount}</span>
-        <p>API Requests</p>
+        <p>REST</p>
+      </div>
+      {#if !isWebApp}
+        <div class="d-flex gap-1">
+          <span class="text-plusButton">{graghQlCount}</span>
+          <p>GraphQL</p>
+        </div>
+      {/if}
+      <div class="d-flex gap-1">
+        <span class="text-plusButton">{webSocketCount}</span>
+        <p>WebSocket</p>
+      </div>
+      <div class="d-flex gap-1">
+        <span class="text-plusButton">{socketIoCount}</span>
+        <p>Socket.IO</p>
       </div>
     </div>
     <div
@@ -287,7 +318,7 @@
               folder: explorer,
             });
           },
-          displayText: "Add REST API",
+          displayText: "Add REST",
           disabled: false,
           hidden:
             !collection.activeSync ||

--- a/packages/@sparrow-workspaces/src/features/folder-explorer/layout/FolderExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/folder-explorer/layout/FolderExplorer.svelte
@@ -37,15 +37,21 @@
   /**
    * Callback to get total number of requests in folder
    */
+
   export let getTotalRequests: (
     collection: CollectionDocument,
     tab: TabDocument,
-  ) => Promise<number>;
-
+  ) => Promise<{
+    totalRequests: number;
+    totalGraphQl: number;
+    totalSocketIo: number;
+    totalWebSocket: number;
+  }>;
   /**
    * Role of user in active workspace
    */
   export let userRole;
+  export let isWebApp = false;
 
   /**
    * Components
@@ -68,12 +74,21 @@
    * Local variables
    */
   let totalRequests: number = 0;
+  let totalGraphQl: number = 0;
+  let totalSocketIo: number = 0;
+  let totalWebSocket: number = 0;
 
   /**
    * Funciton to update total requests
    */
   const updateTotalRequests = async () => {
-    totalRequests = await getTotalRequests(collection, tab);
+    let res = await getTotalRequests(collection, tab);
+    if (res) {
+      totalRequests = res.totalRequests;
+      totalGraphQl = res.totalGraphQl;
+      totalSocketIo = res.totalSocketIo;
+      totalWebSocket = res.totalWebSocket;
+    }
   };
 
   /**
@@ -102,52 +117,64 @@
 
 <div class="main-container d-flex h-100" style="overflow:auto;">
   <div class="my-collection d-flex flex-column w-100 z-3">
-   
-      <div class="d-flex gap-2 mb-4">
-        <div class="d-flex flex-column flex-grow-1">
-          <input
-            type="text"
-            required
-            id="renameInputFieldFolder"
-            value={folder?.name || ""}
-            disabled={tab?.source === "SPEC" ||
-              userRole === WorkspaceRole.WORKSPACE_VIEWER}
-            class="bg-transparent input-outline border-0 text-left w-100 ps-2 py-0 text-fs-18"
-            maxlength={100}
-            on:blur={(event) => {
-              const newValue = event.target.value.trim();
-              const previousValue = folder.name;
-              if (newValue === "") {
-                resetInputField();
-              } else if (newValue !== previousValue) {
-                onRename(collection, folder, newValue);
-              }
-            }}
-            on:keydown={(event) => {
-              if (event.key === "Enter") {
-                onRenameInputKeyPress();
-              }
-            }}
-          />
-        </div>
-        <div class="d-flex flex-row">
-          <button
-            disabled={userRole === WorkspaceRole.WORKSPACE_VIEWER ||
-              tab?.source === "SPEC"}
-            class="btn add-button rounded mx-1 border-0 text-align-right py-1"
-            style="max-height:60px; width:200px; margin-top: -2px;"
-            on:click={() => {
-              onCreateAPIRequest(collection, folder);
-            }}>New Request</button
-          >
-        </div>
+    <div class="d-flex gap-2 mb-4">
+      <div class="d-flex flex-column flex-grow-1">
+        <input
+          type="text"
+          required
+          id="renameInputFieldFolder"
+          value={folder?.name || ""}
+          disabled={tab?.source === "SPEC" ||
+            userRole === WorkspaceRole.WORKSPACE_VIEWER}
+          class="bg-transparent input-outline border-0 text-left w-100 ps-2 py-0 text-fs-18"
+          maxlength={100}
+          on:blur={(event) => {
+            const newValue = event.target.value.trim();
+            const previousValue = folder.name;
+            if (newValue === "") {
+              resetInputField();
+            } else if (newValue !== previousValue) {
+              onRename(collection, folder, newValue);
+            }
+          }}
+          on:keydown={(event) => {
+            if (event.key === "Enter") {
+              onRenameInputKeyPress();
+            }
+          }}
+        />
       </div>
-  
+      <div class="d-flex flex-row">
+        <button
+          disabled={userRole === WorkspaceRole.WORKSPACE_VIEWER ||
+            tab?.source === "SPEC"}
+          class="btn add-button rounded mx-1 border-0 text-align-right py-1"
+          style="max-height:60px; width:200px; margin-top: -2px;"
+          on:click={() => {
+            onCreateAPIRequest(collection, folder);
+          }}>New Request</button
+        >
+      </div>
+    </div>
 
     <div class="d-flex gap-4 mb-4 ps-2">
       <div class="d-flex align-items-center gap-2">
         <span class="fs-4 text-primary-300">{totalRequests}</span>
-        <p style="font-size: 12px;" class="mb-0">API Requests</p>
+        <p style="font-size: 12px;" class="mb-0">REST</p>
+      </div>
+      {#if !isWebApp}
+        <div class="d-flex align-items-center gap-2">
+          <span class="fs-4 text-primary-300">{totalGraphQl}</span>
+          <p style="font-size: 12px;" class="mb-0">GraphQL</p>
+        </div>
+      {/if}
+      <div class="d-flex align-items-center gap-2">
+        <span class="fs-4 text-primary-300">{totalWebSocket}</span>
+        <p style="font-size: 12px;" class="mb-0">WebSocket</p>
+      </div>
+      <div class="d-flex align-items-center gap-2">
+        <span class="fs-4 text-primary-300">{totalSocketIo}</span>
+        <p style="font-size: 12px;" class="mb-0">Socket.IO</p>
       </div>
     </div>
     <div class="d-flex align-items-start ps-0 h-100">


### PR DESCRIPTION
API Request Count 
[#2422](https://github.com/sparrowapp-dev/sparrow-app/issues/2422)

Description : The system should display a real-time count of the following items: Folders, REST API Requests, GraphQL Requests, WebSocket connections, and Socket.IO connections. These counts should update automatically whenever changes occur, ensuring that users always see the most accurate information.

Figma/SS:
![image](https://github.com/user-attachments/assets/dd106182-0137-4573-a101-6c1adf5acdd4)

Acceptance criteria 1: [Count update]
Given User wants to see the count of any of the mentioned aspects Folders, REST API Requests, GraphQL Requests, WebSocket connections, and Socket.IO connections.
When user creates or deletes any of these items in the application.
Then User should be able to see the count of each item should update automatically and reflect the current state.
after solving
![image](https://github.com/user-attachments/assets/a3feed32-340d-475f-98d7-8b5452f1f87b)
