### PR TITLE
fix: Focused state circle issue of radio button.

### DIFF
--- a/packages/@sparrow-library/src/ui/radio-button/RadioButton.svelte
+++ b/packages/@sparrow-library/src/ui/radio-button/RadioButton.svelte
@@ -149,6 +149,10 @@
   .focus-visible-button:focus-visible {
     outline: 2px solid var(--border-ds-primary-300);
   }
+
+  .focus-visible-button:focus-visible .circle-internal {
+    background-color: var(--bg-ds-surface-300) !important;
+  }
   .focus-visible-button:focus-visible .label-text-medium,
   .focus-visible-button:focus-visible .label-text-small {
     color: var(--text-ds-neutral-50) !important;


### PR DESCRIPTION
## Description

I have fixed the circle issue in the Radio button on focus state.
## What type of PR is this? (check all applicable)
- [ ] 🐛 Bug Fix

## Have you tested locally?
- [ ] 👍 yes
