### PR TITLE
fix: Made the testflow start button disabled when no api request bloc…

### DIFF
--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/components/start-block/StartBlock.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/components/start-block/StartBlock.svelte
@@ -78,12 +78,15 @@
     data.onClick("0");
   }}
 >
-  <span
-    ><PlayArrow
-      height={"14px"}
-      width={"12px"}
-      color={"var(--bg-ds-neutral-50)"}
-    /><span class="ms-2 text-fs-12">Start</span>
+  <span>
+    <span style="opacity:{isAddBlockVisible ? '0.4' : '1'}">
+      <PlayArrow
+        height={"14px"}
+        width={"12px"}
+        color={"var(--bg-ds-neutral-50)"}
+      /><span class="ms-2 text-fs-12">Start</span>
+    </span>
+
     <Handle type="source" position={Position.Right} />
     {#if isAddBlockVisible}
       <div

--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/components/start-block/StartBlock.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/components/start-block/StartBlock.svelte
@@ -74,6 +74,7 @@
     : ""}
   class="start-block position-relative"
   on:click={() => {
+    if (isAddBlockVisible) return;
     MixpanelEvent(Events.Start_TestFlows);
     data.onClick("0");
   }}


### PR DESCRIPTION
## Description
Added a temporary disabled state for testflow start button when there is no api request block added in the testflow

## What type of PR is this? (check all applicable)
- [x] 🐛 Bug Fix

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy
