### PR TITLE
fix: fixed the typos for notifications messages

### DIFF
--- a/apps/@sparrow-web/src/containers/api/api.common.ts
+++ b/apps/@sparrow-web/src/containers/api/api.common.ts
@@ -322,7 +322,9 @@ const disconnectWebSocket = async (tab_id: string) => {
         !isEnableWebSocketCloud
       ) {
         socketInsta.close();
-        notifications.success("WebSocket disconnected successfully");
+
+        // ToDo -> Messages and Constants strings/values should be stored in a single script (named Constants) 
+        notifications.success("WebSocket disconnected successfully.");
       } else {
         socketInsta?.emit(
           "sparrow_internal_disconnect",
@@ -422,7 +424,7 @@ const connectWebSocket = async (
             }
             return webSocketDataMap;
           });
-          notifications.success("WebSocket connected successfully");
+          notifications.success("WebSocket connected successfully.");
           resolve("");
         };
 
@@ -540,7 +542,7 @@ const connectWebSocket = async (
           }
           return webSocketDataMap;
         });
-        notifications.success("WebSocket connected successfully");
+        notifications.success("WebSocket connected successfully.");
       } else if (event === "sparrow_internal_disconnect") {
         // Disconnect listener from the target Socket.IO.
         console.error(


### PR DESCRIPTION
## Description
Fixed the message typo in WebSocket connections notification.
**Suggestion:** We should store all the constant strings and values inside a constants file instead of hardcoding the values. It will be helpful for reuse.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy
