### PR TITLE
fix: fixed the wrong block count in the delete popup in testflows

### DIFF
--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
@@ -549,7 +549,9 @@
    */
   const countNextDeletedNode = (id: string) => {
     nodes.subscribe((_nodes) => {
-      deleteCount = _nodes.filter((node) => node.id > id).length;
+      deleteCount = _nodes.filter(
+        (node) => Number(node.id) > Number(id),
+      ).length;
     });
   };
 


### PR DESCRIPTION
## Description
Fixed the count of blocks in the delete popup for block in testflows.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy
