### PR TITLE
Fix: Environment should be de-selected once user check that radio button.

### DIFF
--- a/packages/@sparrow-workspaces/src/features/environment-list/components/list-item/ListItem.svelte
+++ b/packages/@sparrow-workspaces/src/features/environment-list/components/list-item/ListItem.svelte
@@ -224,7 +224,6 @@
   class="environment-tab"
   bind:this={environmentTabWrapper}
   on:click|preventDefault={() => {
-    handleSelectEnvironment();
     if (!isRenaming) {
       if (!env.id.includes(UntrackedItems.UNTRACKED)) {
         openEnvironment();


### PR DESCRIPTION
## Description

I have removed the function call that was affecting the environment selection when the user clicked on the text div.
## What type of PR is this? (check all applicable)
- [x] 🐛 Bug Fix

## Have you tested locally?
- [x] 👍 yes
