### PR TITLE
fix: typography update

### DIFF
--- a/apps/@sparrow-desktop/src/components/styles.css
+++ b/apps/@sparrow-desktop/src/components/styles.css
@@ -1,13 +1,19 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,500;1,600;1,700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,900;1,100;1,300;1,400;1,500;1,900&family=Source+Sans+3:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200&family=Source+Serif+4:wght@300&display=swap");
+@import url("https://rsms.me/inter/inter.css"); /* Inter Font */
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap"); /* JetBrains Mono Font */
 
 * {
   margin: 0px;
   padding: 0px;
-  font-family: "Roboto", sans-serif;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
+@supports (font-variation-settings: normal) {
+  * {
+    font-family: InterVariable, sans-serif;
+  }
+}
+
 img,
 a {
   user-drag: none; /* Standard syntax */

--- a/apps/@sparrow-desktop/src/components/styles.css
+++ b/apps/@sparrow-desktop/src/components/styles.css
@@ -8,6 +8,7 @@
   -ms-user-select: none;
   user-select: none;
 }
+
 @supports (font-variation-settings: normal) {
   * {
     font-family: InterVariable, sans-serif;

--- a/apps/@sparrow-web/src/components/styles.css
+++ b/apps/@sparrow-web/src/components/styles.css
@@ -1,13 +1,19 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,500;1,600;1,700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,900;1,100;1,300;1,400;1,500;1,900&family=Source+Sans+3:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200&family=Source+Serif+4:wght@300&display=swap");
+@import url("https://rsms.me/inter/inter.css"); /* Inter Font */
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap"); /* JetBrains Mono Font */
 
 * {
   margin: 0px;
   padding: 0px;
-  font-family: "Roboto", sans-serif;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
+@supports (font-variation-settings: normal) {
+  * {
+    font-family: InterVariable, sans-serif;
+  }
+}
+
 img,
 a {
   user-drag: none; /* Standard syntax */

--- a/packages/@sparrow-common/src/constants/fonts.constant.ts
+++ b/packages/@sparrow-common/src/constants/fonts.constant.ts
@@ -1,3 +1,3 @@
-const EditorFont = "'Source Code Pro', monospace !important";
+const EditorFont = "'JetBrains Mono', monospace !important";
 
 export { EditorFont };

--- a/packages/@sparrow-library/src/ui/button/Button.svelte
+++ b/packages/@sparrow-library/src/ui/button/Button.svelte
@@ -235,7 +235,7 @@
   {:else if title}
     <span
       class="btn-title"
-      style={`font-size:${fontSize}px; font-weight:500; `}
+      style={`font-size:${fontSize}px; font-weight:400; `}
     >
       {title}
     </span>

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/collection/Collection.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/collection/Collection.svelte
@@ -505,7 +505,7 @@
         class="py-0 renameInputFieldCollection w-100 ellipsis"
         id="renameInputFieldCollection"
         type="text"
-        style="font-size: 12px; font-weight:500; line-height:18px; gap: 4px; "
+        style="font-size: 12px; font-weight:400; line-height:18px; gap: 4px; "
         value={collection.name}
         maxlength={100}
         bind:this={inputField}
@@ -521,7 +521,7 @@
       >
         <p
           class="ellipsis mb-0"
-          style="font-size: 12px; font-weight:500; line-height:18px;  "
+          style="font-size: 12px; font-weight:400; line-height:18px;  "
         >
           {collection.name}
         </p>

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
@@ -458,7 +458,7 @@
               class="py-0 renameInputFieldFolder w-100"
               id="renameInputFieldFolder"
               type="text"
-              style="font-size: 12px; padding-left:5px; font-weight:500; color : var(--text-ds-neutral-50); line-height:18px;"
+              style="font-size: 12px; padding-left:5px; font-weight:400; color : var(--text-ds-neutral-50); line-height:18px;"
               autofocus
               maxlength={100}
               value={explorer.name}
@@ -472,7 +472,7 @@
               class="folder-title d-flex align-items-center"
               style="cursor:pointer; font-size:12px;
                       height: 32px;
-                      font-weight:500;
+                      font-weight:400;
                       margin-left:0px;
                       font-size:12px;
                       color:var(--text-ds-neutral-50);

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/graphql/Graphql.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/graphql/Graphql.svelte
@@ -288,7 +288,7 @@
     {:else}
       <div
         class="api-name ellipsis {graphql?.isDeleted && 'api-name-deleted'}"
-        style="font-size: 12px; "
+        style="font-size: 12px; font-weight:400;"
       >
         <p class=" ellipsis m-0 p-0">{graphql.name}</p>
       </div>
@@ -326,11 +326,11 @@
 <style lang="scss">
   .delete-ticker {
     color: var(--error--color);
-    font-weight: 500;
+    font-weight: 400;
   }
   .api-method {
     font-size: 10px;
-    font-weight: 500;
+    font-weight: 400;
     width: 30px !important;
     height: 24px;
 

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/request/Request.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/request/Request.svelte
@@ -346,7 +346,7 @@
     {:else}
       <div
         class="api-name ellipsis {api?.isDeleted && 'api-name-deleted'}"
-        style="font-size: 12px;"
+        style="font-size: 12px; font-weight:400;"
       >
         <p class="ellipsis m-0 p-0">
           {api.name}
@@ -414,7 +414,7 @@
   }
   .api-method {
     font-size: 9px;
-    font-weight: 600;
+    font-weight: 500;
     width: 30px !important;
     height: 24px;
     border-radius: 4px;

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/socket-io/SocketIo.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/socket-io/SocketIo.svelte
@@ -270,7 +270,7 @@
     {#if isRenaming}
       <input
         class="py-0 rename-input-field-socket-io"
-        style="font-size: 12px; font-weight:500; line-height:18px;  width: calc(100% - 50px);"
+        style="font-size: 12px; font-weight:400; line-height:18px;  width: calc(100% - 50px);"
         id="renameInputFieldSocketIo"
         type="text"
         maxlength={100}
@@ -340,7 +340,7 @@
   .api-name {
     height: 24px;
     line-height: 18px;
-    font-weight: 500;
+    font-weight: 400;
     width: calc(100% - 58px);
     text-align: left;
     color: var(--bg-ds-neutral-50);

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/web-socket/WebSocket.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/web-socket/WebSocket.svelte
@@ -282,7 +282,7 @@
     {#if isRenaming}
       <input
         class="py-0 renameInputFieldFile"
-        style="font-size: 12px; width: calc(100% - 50px); font-weight:500; line-height:18px;"
+        style="font-size: 12px; width: calc(100% - 50px); font-weight:400; line-height:18px;"
         id="renameInputFieldFile"
         type="text"
         maxlength={100}
@@ -296,7 +296,7 @@
     {:else}
       <div
         class="api-name ellipsis {api?.isDeleted && 'api-name-deleted'}"
-        style="font-size: 12px; font-weight:500; line-height:18px;"
+        style="font-size: 12px; font-weight:400; line-height:18px;"
       >
         <p class="ellipsis m-0 p-0">{api.name}</p>
       </div>

--- a/packages/@sparrow-workspaces/src/features/collection-list/layout/CollectionList.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/layout/CollectionList.svelte
@@ -250,7 +250,7 @@
         >
           <p
             class="sparrow-fs-13 mb-0"
-            style="font-weight: 500; font-size:12px; line-height:18px; color:var(--text-ds-neutral-50); "
+            style="font-weight:400; font-size:12px; line-height:18px; color:var(--text-ds-neutral-50); "
           >
             Collections
           </p>

--- a/packages/@sparrow-workspaces/src/features/environment-list/components/list-item/ListItem.svelte
+++ b/packages/@sparrow-workspaces/src/features/environment-list/components/list-item/ListItem.svelte
@@ -272,7 +272,7 @@
       {#if isRenaming}
         <input
           class="py-0 renameInputFieldCollection text-fs-12 w-100"
-          style="font-size: 12px; font-weight:500; line-height:18px;"
+          style="font-size: 12px; font-weight:400; line-height:18px;"
           id="renameInputFieldEnvironment"
           type="text"
           value={env.name}
@@ -286,7 +286,7 @@
       {:else}
         <div
           class="collection-title d-flex align-items-center py-1 mb-0"
-          style="height: 32px; font-size:12px; font-weight:500; line-height:18px; padding:2px 4px; "
+          style="height: 32px; font-size:12px; font-weight:400; line-height:18px; padding:2px 4px; "
         >
           <p class="ellipsis w-100 me-4 mb-0 text-fs-12">
             {env.name}

--- a/packages/@sparrow-workspaces/src/features/environment-list/layout/EnvironmentList.svelte
+++ b/packages/@sparrow-workspaces/src/features/environment-list/layout/EnvironmentList.svelte
@@ -182,7 +182,7 @@
       <span style="padding:2px 4px;">
         <p
           class=" mb-0 sparrow-fs-13"
-          style="font-weight: 500; font-size:12px; line-height:18px;"
+          style="font-weight:400; font-size:12px; line-height:18px;"
         >
           Environments
         </p>
@@ -225,7 +225,7 @@
           <p
             tabindex="0"
             role="button"
-            class={`fw-normal   env-item text-fs-12 border-radius-2  ${
+            class={`fw-normal env-item text-fs-12 border-radius-2  ${
               globalEnvironment[0]?.id === activeTabId && "active"
             }`}
             style="height: 32px; display:flex; align-items:center; padding-left:18px; margin-bottom:2px; position:relative; gap:0px;"
@@ -243,7 +243,7 @@
             </span>
 
             <span class="box-line1"></span>
-            <span class="" style="padding: 2px 4px;"
+            <span class="" style="padding: 2px 4px; font-weight: 400;"
               >{globalEnvironment[0]?.name}
             </span>
           </p>

--- a/packages/@sparrow-workspaces/src/features/testflow-list/components/testflow-list-item/TestflowListItem.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-list/components/testflow-list-item/TestflowListItem.svelte
@@ -260,7 +260,7 @@
       {:else}
         <div
           class="collection-title d-flex align-items-center py-1 mb-0"
-          style="height: 32px; font-size:12px; font-weight:500; line-height:18px;"
+          style="height: 32px; font-size:12px; font-weight:400; line-height:18px;"
         >
           <p class="ellipsis w-100 me-4 mb-0">
             {flow.name}

--- a/packages/@sparrow-workspaces/src/features/testflow-list/layout/TestflowList.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-list/layout/TestflowList.svelte
@@ -165,7 +165,7 @@
       <span style="padding:2px 4px;">
         <p
           class=" mb-0 sparrow-fs-13"
-          style="font-weight: 500; font-size:12px; line-height:18px;   "
+          style="font-weight:400; font-size:12px; line-height:18px;"
         >
           Test Flows
         </p>


### PR DESCRIPTION
### Description
Update app typography from Roboto to Inter; JetBrains for code editor. Adjusted side nav font weight to match Figma
This change is impplemented in 

### Add Issue Number
issue: [#2839](https://github.com/sparrowapp-dev/sparrow-app/issues/2839)

### Add Screenshots/GIFs
after:
![image](https://github.com/user-attachments/assets/0d3aba69-2297-4a54-9e8a-ba3ebccd5a07)
before:
![image](https://github.com/user-attachments/assets/691c5310-649b-4400-90eb-9a5dfb199464)


### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.