### PR TITLE
fix: Truncating the tab names if too long

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
@@ -608,6 +608,7 @@
     startAutoRefresh();
   });
 
+  // ToDo: Need to move the truncate functionality to `modal` component itself
   const truncateTabName = (name, maxLength = 15) => {
     if (!name) return "Untitled";
     return name.length > maxLength

--- a/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
@@ -607,6 +607,13 @@
   onMount(() => {
     startAutoRefresh();
   });
+
+  const truncateTabName = (name, maxLength = 15) => {
+    if (!name) return "Untitled";
+    return name.length > maxLength
+      ? `${name.substring(0, maxLength)}...`
+      : name;
+  };
 </script>
 
 <Motion {...pagesMotion} let:motion>
@@ -860,7 +867,7 @@
       Do you want to save changes in this tab “<span
         class="text-whiteColor fw-bold"
       >
-        {!removeTab ? "Untitled" : removeTab.name}</span
+        {!removeTab ? "Untitled" : truncateTabName(removeTab.name)}</span
       >”? Changes will be lost in case you choose not to save.
     </p>
   </div>

--- a/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
@@ -868,7 +868,7 @@
       Do you want to save changes in this tab “<span
         class="text-whiteColor fw-bold"
       >
-        {!removeTab ? "Untitled" : truncateTabName(removeTab.name)}</span
+        {!removeTab ? "Untitled" : truncateTabName(removeTab.name, 25)}</span
       >”? Changes will be lost in case you choose not to save.
     </p>
   </div>

--- a/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
@@ -513,7 +513,7 @@
   const cw = currentWorkspace.subscribe(async (value) => {
     if (value) {
       if (prevWorkspaceId !== value._id) {
-        await handleRefreshApicalls(value?._id);
+        await handleRefreshApicalls(value._id);
 
         userValidationStore.subscribe((validation) => {
           if (!validation.isValid) {
@@ -641,6 +641,14 @@
   onMount(() => {
     startAutoRefresh();
   });
+
+  
+  const truncateTabName = (name, maxLength = 15) => {
+    if (!name) return "Untitled";
+    return name.length > maxLength
+      ? `${name.substring(0, maxLength)}...`
+      : name;
+  };
 </script>
 
 <Motion {...pagesMotion} let:motion>
@@ -898,7 +906,7 @@
       Do you want to save changes in this tab “<span
         class="text-whiteColor fw-bold"
       >
-        {!removeTab ? "Untitled" : removeTab.name}</span
+        {!removeTab ? "Untitled" : truncateTabName(removeTab.name, 25)}</span
       >”? Changes will be lost in case you choose not to save.
     </p>
   </div>

--- a/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
@@ -513,7 +513,7 @@
   const cw = currentWorkspace.subscribe(async (value) => {
     if (value) {
       if (prevWorkspaceId !== value._id) {
-        await handleRefreshApicalls(value._id);
+        await handleRefreshApicalls(value?._id);
 
         userValidationStore.subscribe((validation) => {
           if (!validation.isValid) {


### PR DESCRIPTION
### Description
Truncating the tab name if too long 

### Add Issue Number
Self Reported Bug
No Issue reported 

### Add Screenshots/GIFs
<img width="959" alt="image" src="https://github.com/user-attachments/assets/58192a68-c339-44ef-b0f1-ab14005875e6" />

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.