### PR TITLE
fix: Auto select environment issue while creating new environment in new workspace

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
@@ -123,7 +123,7 @@
 
   let localEnvironment;
   let globalEnvironment;
-  // let hasSetInitialEnvironment = false;
+  let hasSetInitialEnvironment = false;
 
   let isFirstCollectionExpand;
 
@@ -175,26 +175,24 @@
     }
   }
 
-  // Rolling back the changes for auto select environment - Require Fix
-  ///////////////////////////////////////////////////////
   // Auto select environment for the first time - st
-  //////////////////////////////////////////////////////
-  // $: {
-  //   // Set the first environment by default from the list if no env. already set.
-  //   if (!hasSetInitialEnvironment && localEnvironment?.length > 0) {
-  //     setInitialEnvironment();
-  //   }
-  // }
-
-  // // Function to handle default environment selection
-  // async function setInitialEnvironment() {
-  //   if (hasSetInitialEnvironment) return;
-  //   const currActiveEnv = currentWOrkspaceValue.environmentId;
-  //   if (!currActiveEnv)
-  //     await _viewModel2.onSelectEnvironment(localEnvironment[0]);
-  //   hasSetInitialEnvironment = true;
-  // }
-  // Auto select environment for the first time - End
+  async function setInitialEnvironment(workspaceId: string) {
+    if (!workspaceId) return;
+    const wkEnvs = await _viewModel2.getEnvironmentByWorkspaceId(workspaceId);
+    
+    if (
+      currentWOrkspaceValue &&
+      !hasSetInitialEnvironment &&
+      wkEnvs?.length > 1
+    ) {
+      const currActiveEnv = currentWOrkspaceValue?.environmentId;
+      if (!currActiveEnv) {
+        await _viewModel2.onSelectEnvironment(wkEnvs[1]);
+        hasSetInitialEnvironment = true;
+        // notifications.warning(`Environment is selected by default!`);
+      }
+    }
+  }
 
   let onCreateEnvironment = _viewModel2.onCreateEnvironment;
 
@@ -519,6 +517,8 @@
         tabList = _viewModel.getTabListWithWorkspaceId(value._id);
         activeTab = _viewModel.getActiveTab(value._id);
         totalTeamCount = value._data?.users?.length;
+
+        setInitialEnvironment(value._id);
       }
       prevWorkspaceId = value._id;
       if (count == 0) {

--- a/apps/@sparrow-desktop/src/pages/workspace-page/EnvironmentPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/EnvironmentPage.ViewModel.ts
@@ -124,6 +124,12 @@ export class EnvironmentViewModel {
     return null;
   };
 
+  public getEnvironmentByWorkspaceId = async (workspaceId: string) => {
+    const environments =
+      await this.environmentRepository.getEnvironmentByWorkspaceId(workspaceId);
+    return environments;
+  };
+
   /**
    * @description - creates new environment
    * @param localEnvironment - new environment data

--- a/apps/@sparrow-web/index.html
+++ b/apps/@sparrow-web/index.html
@@ -53,6 +53,7 @@
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
     <script>
+      console.warn = () => {};
       // Hide the loader after the window is fully loaded
       window.addEventListener("load", function () {
         setTimeout(() => {

--- a/apps/@sparrow-web/index.html
+++ b/apps/@sparrow-web/index.html
@@ -53,7 +53,6 @@
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
     <script>
-      console.warn = () => {};
       // Hide the loader after the window is fully loaded
       window.addEventListener("load", function () {
         setTimeout(() => {

--- a/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
@@ -176,67 +176,24 @@
     }
   }
 
-  // Rolling back the changes for auto select environment - Require Fix
-  ///////////////////////////////////////////////////////
   // Auto select environment for the first time - st
-  //////////////////////////////////////////////////////
-  async function fetchAndSetEnvironments(workspaceId) {
-    console.log("2. Inside fS() : ", workspaceId);
+  async function setInitialEnvironment(workspaceId: string) {
     if (!workspaceId) return;
-    console.log("3. Inside fS() : ");
-
     const wkEnvs = await _viewModel2.getEnvironmentByWorkspaceId(workspaceId);
-    console.log("4. Inside fS() : ", wkEnvs);
 
-    console.log(
-      "5. Inside fS() : ",
-      currentWOrkspaceValue,
-      hasSetInitialEnvironment,
-    );
-    // Set the first environment by default from the list if no env. already set.
     if (
       currentWOrkspaceValue &&
       !hasSetInitialEnvironment &&
       wkEnvs?.length > 1
     ) {
-      console.log("6. Inside fS() : ");
-      setInitialEnvironment(wkEnvs);
+      const currActiveEnv = currentWOrkspaceValue?.environmentId;
+      if (!currActiveEnv) {
+        await _viewModel2.onSelectEnvironment(wkEnvs[1]);
+        hasSetInitialEnvironment = true;
+        // notifications.warning(`Environment is selected by default!`);
+      }
     }
   }
-
-  // Function to handle default environment selection
-  async function setInitialEnvironment(wkEnvs) {
-    console.log("7. Inside SE() : ", currentWOrkspaceValue);
-    if (hasSetInitialEnvironment) return;
-    console.log("8. Inside SE() : ");
-    const currActiveEnv = currentWOrkspaceValue.environmentId;
-    console.log("9. Inside SE() : ", currActiveEnv);
-    if (!currActiveEnv) {
-      console.log("10. Inside SE() : ", wkEnvs[1]);
-      await _viewModel2.onSelectEnvironment(wkEnvs[1]);
-      hasSetInitialEnvironment = true;
-      notifications.warning(
-        `Environment ${wkEnvs[1].name} is selected by default! `,
-      );
-    }
-  }
-  // $: {
-  //   console.log("1. curr Wk :>> ", currentWOrkspaceValue);
-  //   if (currentWOrkspaceValue?._id) {
-  //     setTimeout(() => {
-  //       fetchAndSetEnvironments(currentWOrkspaceValue._id);
-  //     }, 1000);
-  //   }
-  // }
-
-  // Function to handle default environment selection
-  // async function setInitialEnvironment(wkEnvs) {
-  //   if (hasSetInitialEnvironment) return;
-  //   const currActiveEnv = currentWOrkspaceValue.environmentId;
-  //   if (!currActiveEnv) await _viewModel2.onSelectEnvironment(wkEnvs[0]);
-  //   hasSetInitialEnvironment = true;
-  // }
-  // // Auto select environment for the first time - End
 
   let onCreateEnvironment = _viewModel2.onCreateEnvironment;
 
@@ -567,7 +524,7 @@
         activeTab = _viewModel.getActiveTab(value._id);
         totalTeamCount = value._data?.users?.length;
 
-        await fetchAndSetEnvironments(value._id);
+        await setInitialEnvironment(value._id);
       }
       prevWorkspaceId = value._id;
       if (count == 0) {

--- a/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
@@ -125,7 +125,7 @@
 
   let localEnvironment;
   let globalEnvironment;
-  // let hasSetInitialEnvironment = false;
+  let hasSetInitialEnvironment = false;
 
   let environments = _viewModel2.environments;
   let totalCollectionCount = writable(0);
@@ -180,19 +180,60 @@
   ///////////////////////////////////////////////////////
   // Auto select environment for the first time - st
   //////////////////////////////////////////////////////
+  async function fetchAndSetEnvironments(workspaceId) {
+    console.log("2. Inside fS() : ", workspaceId);
+    if (!workspaceId) return;
+    console.log("3. Inside fS() : ");
+
+    const wkEnvs = await _viewModel2.getEnvironmentByWorkspaceId(workspaceId);
+    console.log("4. Inside fS() : ", wkEnvs);
+
+    console.log(
+      "5. Inside fS() : ",
+      currentWOrkspaceValue,
+      hasSetInitialEnvironment,
+    );
+    // Set the first environment by default from the list if no env. already set.
+    if (
+      currentWOrkspaceValue &&
+      !hasSetInitialEnvironment &&
+      wkEnvs?.length > 1
+    ) {
+      console.log("6. Inside fS() : ");
+      setInitialEnvironment(wkEnvs);
+    }
+  }
+
+  // Function to handle default environment selection
+  async function setInitialEnvironment(wkEnvs) {
+    console.log("7. Inside SE() : ", currentWOrkspaceValue);
+    if (hasSetInitialEnvironment) return;
+    console.log("8. Inside SE() : ");
+    const currActiveEnv = currentWOrkspaceValue.environmentId;
+    console.log("9. Inside SE() : ", currActiveEnv);
+    if (!currActiveEnv) {
+      console.log("10. Inside SE() : ", wkEnvs[1]);
+      await _viewModel2.onSelectEnvironment(wkEnvs[1]);
+      hasSetInitialEnvironment = true;
+      notifications.warning(
+        `Environment ${wkEnvs[1].name} is selected by default! `,
+      );
+    }
+  }
   // $: {
-  //   // Set the first environment by default from the list if no env. already set.
-  //   if (!hasSetInitialEnvironment && localEnvironment?.length > 0) {
-  //     setInitialEnvironment();
+  //   console.log("1. curr Wk :>> ", currentWOrkspaceValue);
+  //   if (currentWOrkspaceValue?._id) {
+  //     setTimeout(() => {
+  //       fetchAndSetEnvironments(currentWOrkspaceValue._id);
+  //     }, 1000);
   //   }
   // }
 
-  // // Function to handle default environment selection
-  // async function setInitialEnvironment() {
+  // Function to handle default environment selection
+  // async function setInitialEnvironment(wkEnvs) {
   //   if (hasSetInitialEnvironment) return;
   //   const currActiveEnv = currentWOrkspaceValue.environmentId;
-  //   if (!currActiveEnv)
-  //     await _viewModel2.onSelectEnvironment(localEnvironment[0]);
+  //   if (!currActiveEnv) await _viewModel2.onSelectEnvironment(wkEnvs[0]);
   //   hasSetInitialEnvironment = true;
   // }
   // // Auto select environment for the first time - End
@@ -525,6 +566,8 @@
         tabList = _viewModel.getTabListWithWorkspaceId(value._id);
         activeTab = _viewModel.getActiveTab(value._id);
         totalTeamCount = value._data?.users?.length;
+
+        await fetchAndSetEnvironments(value._id);
       }
       prevWorkspaceId = value._id;
       if (count == 0) {

--- a/apps/@sparrow-web/src/pages/workspace-page/EnvironmentPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/EnvironmentPage.ViewModel.ts
@@ -124,6 +124,12 @@ export class EnvironmentViewModel {
     return null;
   };
 
+  public getEnvironmentByWorkspaceId = async (workspaceId: string) => {
+    const environments =
+      await this.environmentRepository.getEnvironmentByWorkspaceId(workspaceId);
+    return environments;
+  };
+
   /**
    * @description - creates new environment
    * @param localEnvironment - new environment data


### PR DESCRIPTION
### Description
The Issue was while creating new environment in a fresh new workspace, the newly created environment was getting selected and even the select state was inconsistent on dashboard environment button and the radio button of environment list.

Now auto select environment will work only when user came after login, if a workspace has any local environment created inside it then first environment in the list will get selected automatically, even while switching to workspaces first time after login. In the newly created workspace no auto select functionality will work because there will be no environment to select for the first time and even if the created a new environment then also no auto select will work. Auto select will work only if there are already existing environments. Environments which is created afterwards will have no effect of auto select.

### Add Issue Number
Fixes #2707 

### Add Screenshots/GIFs
Working
https://github.com/user-attachments/assets/80c9916d-5648-4888-8fb6-8c719b11709f

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.