### PR TITLE
fix : bugs solve in global Search and left panel workspace

### DIFF
--- a/packages/@sparrow-common/src/features/global-search/components/RecentItems/RecentItems.svelte
+++ b/packages/@sparrow-common/src/features/global-search/components/RecentItems/RecentItems.svelte
@@ -241,7 +241,9 @@
     {#if searchQuery === ""}
       {#each recentSections as section (section.key)}
         {#if section.condition}
-          <TitleBar data={selectedTypeMapping[section.key]} />
+          {#if isGuestUser && section.key === "workspaces"}{:else}
+            <TitleBar data={selectedTypeMapping[section.key]} />
+          {/if}
           {#each section.items as item}
             {#if section.key === "requests"}
               {#if !(isWebApp && item.tree.request.method === "GRAPHQL")}

--- a/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-list/components/folder/Folder.svelte
@@ -127,11 +127,11 @@
     if (searchData) {
       expand = true;
     }
-    if (activeTabPath) {
-      if (activeTabPath?.folderId === explorer.id) {
-        expand = true;
-      }
-    }
+    // if (activeTabPath) {
+    // if (activeTabPath?.folderId === explorer.id) {
+    //   expand = true;
+    // }
+    // }
     if (explorer) {
       requestIds = [];
       requestCount = 0;


### PR DESCRIPTION
### Description
bug 1 : When user create new collection, it should open in opened state instead of close state.(Same behaviour as folder)
bug 2 : From Edge, remove this recent workspace option, as it is not present in top.

### Add Issue Number
Fixes #<your_issue_number>

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/4694db47-4a1f-45d5-943f-46426252b45e)

### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [*] **The pull request only addresses one issue or adds one feature.**
- [*] **I have linked an issue to the pull request.**
- [*] **I have linked a PR type label to the pull request.**
- [*] **The pull request does not introduce any breaking changes**
- [*] **I have added screenshots or gifs to help explain the change if applicable.**
- [*] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.