### PR TITLE
fix: disable clear input CTA if editor is empty

### DIFF
--- a/packages/@sparrow-workspaces/src/features/socket-explorer/components/request-body/SocketMessage.svelte
+++ b/packages/@sparrow-workspaces/src/features/socket-explorer/components/request-body/SocketMessage.svelte
@@ -42,15 +42,15 @@
         <div></div>
         <div>
           <Button
-          type="teritiary-regular"
-          startIcon={BroomRegular}
-          onClick={onClearInput}
-          title="Clear Inputs"
-          size="small"
+            type="teritiary-regular"
+            startIcon={BroomRegular}
+            onClick={onClearInput}
+            title="Clear Inputs"
+            size="small"
+            disable={!body || body.trim() === ""}
           />
         </div>
       </div>
     </div>
   </div>
 </div>
-

--- a/packages/@sparrow-workspaces/src/features/socketio-explorer/components/request-body/RequestMessage.svelte
+++ b/packages/@sparrow-workspaces/src/features/socketio-explorer/components/request-body/RequestMessage.svelte
@@ -45,12 +45,13 @@
       >
         <div></div>
         <div>
-           <Button
-          type="teritiary-regular"
-          startIcon={BroomRegular}
-          onClick={onClearInput}
-          title="Clear Inputs"
-          size="small"
+          <Button
+            type="teritiary-regular"
+            startIcon={BroomRegular}
+            onClick={onClearInput}
+            title="Clear Inputs"
+            size="small"
+            disable={!body || body.trim() === ""}
           />
         </div>
       </div>


### PR DESCRIPTION
### Description
Disable clear input button when input is empty.

### Add Issue Number
Fixes #<your_issue_number>

### Add Screenshots/GIFs

https://github.com/user-attachments/assets/6b136448-19c3-4b82-9d38-74d86fa51e63



### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.