### PR TITLE
fix: save shortcuts on Collection, Workspace, Environment, WebSocket & Socket.IO

### DIFF
--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/WebSocketExplorerPage/WebSocketExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/WebSocketExplorerPage/WebSocketExplorerPage.ViewModel.ts
@@ -728,14 +728,17 @@ class RestExplorerViewModel {
       };
     }
     const baseUrl = await this.constructBaseUrl(workspaceId);
-    const res = await this.collectionService.updateSocketInCollection(_id, {
-      collectionId: collectionId,
-      workspaceId: workspaceId,
-      ...folderSource,
-      ...userSource,
-      items: itemSource,
+    const res = await this.collectionService.updateSocketInCollection(
+      _id,
+      {
+        collectionId: collectionId,
+        workspaceId: workspaceId,
+        ...folderSource,
+        ...userSource,
+        items: itemSource,
+      },
       baseUrl,
-    });
+    );
 
     if (res.isSuccessful) {
       const progressiveTab = this._tab.getValue();

--- a/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/collection-explorer/layout/CollectionExplorer.svelte
@@ -87,6 +87,7 @@
   import { GraphqlRequestDefaultAliasBaseEnum } from "@sparrow/common/types/workspace/graphql-request-base";
   import { SocketIORequestDefaultAliasBaseEnum } from "@sparrow/common/types/workspace/socket-io-request-base";
   import { Input } from "@sparrow/library/forms";
+  import { onDestroy, onMount } from "svelte";
 
   /**
    * Role of user in active workspace
@@ -222,6 +223,24 @@
   ];
 
   let isBackgroundClickable = true;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      event.preventDefault();
+
+      if (isCollectionEditable && $tab && !$tab.isSaved) {
+        onSaveCollection();
+      }
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeyDown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", handleKeyDown);
+  });
 </script>
 
 <div class="main-container d-flex h-100" style="overflow:auto;">

--- a/packages/@sparrow-workspaces/src/features/environment-explorer/layout/EnvironmentExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/environment-explorer/layout/EnvironmentExplorer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { HelpIcon, SaveIcon } from "@sparrow/library/assets";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import type { EnvValuePair } from "@sparrow/common/interfaces/request.interface";
   import { QuickHelp } from "../components";
   import { Search } from "@sparrow/library/forms";
@@ -72,6 +72,21 @@
   };
   let isGuidePopup = false;
 
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      event.preventDefault();
+      const canSave = !(
+        $currentEnvironment?.property?.environment?.state?.isSaveInProgress ||
+        $currentEnvironment?.isSaved ||
+        userRole === WorkspaceRole.WORKSPACE_VIEWER
+      );
+
+      if (canSave && $currentEnvironment?.tabId) {
+        onSaveEnvironment();
+      }
+    }
+  };
+
   onMount(async () => {
     const event = await onFetchEnvironmentGuide({
       id: "environment-guide",
@@ -81,6 +96,12 @@
     } else {
       isPopoverContainer = false;
     }
+
+    window.addEventListener("keydown", handleKeyDown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", handleKeyDown);
   });
 </script>
 
@@ -123,29 +144,6 @@
           </button>
         {/if}
 
-        <!-- <Input
-          id={"environment-name"}
-          width={"calc(100% - 500px)"}
-          type="text"
-          bind:value={environmentName}
-          on:input={(e) => {
-            handleCurrentEnvironmentNameChange(environmentName, "");
-          }}
-          on:blur={(e) => {
-            handleCurrentEnvironmentNameChange(environmentName, "blur");
-          }}
-          defaultBorderColor="transparent"
-          hoveredBorderColor={"var(--border-ds-primary-300)"}
-          focusedBorderColor={"var(--border-ds-primary-300)"}
-          class="text-fs-18 bg-transparent ellipsis fw-normal px-2 rounded-1 "
-          style="outline:none;"
-          disabled={$currentEnvironment?.property?.environment?.type ==
-            "GLOBAL" || userRole === WorkspaceRole.WORKSPACE_VIEWER}
-          placeholder=""
-          height="36px"
-          isPencilIconRequired={false}
-        /> -->
-
         <Input
           type={"text"}
           size={"medium"}
@@ -179,7 +177,11 @@
           </div>
 
           <div class="position-relative">
-            <Tooltip title="Save" placement="bottom-center" distance={10}>
+            <Tooltip
+              title="Save (Ctrl+S)"
+              placement="bottom-center"
+              distance={10}
+            >
               <Button
                 type="primary"
                 startIcon={SaveRegular}

--- a/packages/@sparrow-workspaces/src/features/environment-explorer/layout/EnvironmentExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/environment-explorer/layout/EnvironmentExplorer.svelte
@@ -144,6 +144,29 @@
           </button>
         {/if}
 
+        <!-- <Input
+          id={"environment-name"}
+          width={"calc(100% - 500px)"}
+          type="text"
+          bind:value={environmentName}
+          on:input={(e) => {
+            handleCurrentEnvironmentNameChange(environmentName, "");
+          }}
+          on:blur={(e) => {
+            handleCurrentEnvironmentNameChange(environmentName, "blur");
+          }}
+          defaultBorderColor="transparent"
+          hoveredBorderColor={"var(--border-ds-primary-300)"}
+          focusedBorderColor={"var(--border-ds-primary-300)"}
+          class="text-fs-18 bg-transparent ellipsis fw-normal px-2 rounded-1 "
+          style="outline:none;"
+          disabled={$currentEnvironment?.property?.environment?.type ==
+            "GLOBAL" || userRole === WorkspaceRole.WORKSPACE_VIEWER}
+          placeholder=""
+          height="36px"
+          isPencilIconRequired={false}
+        /> -->
+
         <Input
           type={"text"}
           size={"medium"}

--- a/packages/@sparrow-workspaces/src/features/socket-explorer/layout/SocketExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/socket-explorer/layout/SocketExplorer.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Loader } from "@sparrow/library/ui";
+  import { Loader, notifications } from "@sparrow/library/ui";
   import { Modal } from "@sparrow/library/ui";
   import { Splitpanes, Pane } from "svelte-splitpanes";
+  import { onMount, onDestroy } from "svelte";
 
   import type { CollectionDocument } from "@app/database/database";
   import type { Observable } from "rxjs";
@@ -82,6 +83,29 @@
     } else {
       loading.set(tabIdValue);
     }
+  });
+
+  const handleKeydown = async (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      event.preventDefault();
+      const x = await onSaveSocket();
+      if (
+        x.status === "error" &&
+        x.message === "request is not a part of any workspace or collection"
+      ) {
+        toggleSaveRequest(true);
+      } else if (x.status === "success") {
+        notifications.success("WebSocket request saved successfully.");
+      }
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", handleKeydown);
   });
 </script>
 

--- a/packages/@sparrow-workspaces/src/features/socket-explorer/layout/SocketExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/socket-explorer/layout/SocketExplorer.svelte
@@ -88,14 +88,16 @@
   const handleKeydown = async (event: KeyboardEvent) => {
     if ((event.ctrlKey || event.metaKey) && event.key === "s") {
       event.preventDefault();
-      const x = await onSaveSocket();
-      if (
-        x.status === "error" &&
-        x.message === "request is not a part of any workspace or collection"
-      ) {
-        toggleSaveRequest(true);
-      } else if (x.status === "success") {
-        notifications.success("WebSocket request saved successfully.");
+      if (!$tab.isSaved) {
+        const x = await onSaveSocket();
+        if (
+          x.status === "error" &&
+          x.message === "request is not a part of any workspace or collection"
+        ) {
+          toggleSaveRequest(true);
+        } else if (x.status === "success") {
+          notifications.success("WebSocket request saved successfully.");
+        }
       }
     }
   };

--- a/packages/@sparrow-workspaces/src/features/socketio-explorer/layout/SocketIoExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/socketio-explorer/layout/SocketIoExplorer.svelte
@@ -92,16 +92,18 @@
   const handleKeydown = async (event: KeyboardEvent) => {
     if ((event.ctrlKey || event.metaKey) && event.key === "s") {
       event.preventDefault();
-      const x = await onSaveSocket();
-      if (
-        x.status === "error" &&
-        x.message === "request is not a part of any workspace or collection"
-      ) {
-        toggleSaveRequest(true);
-      } else if (x.status === "success") {
-        notifications.success(
-          `${SocketIORequestDefaultAliasBaseEnum.NAME} request saved successfully.`,
-        );
+      if (!$tab.isSaved) {
+        const x = await onSaveSocket();
+        if (
+          x.status === "error" &&
+          x.message === "request is not a part of any workspace or collection"
+        ) {
+          toggleSaveRequest(true);
+        } else if (x.status === "success") {
+          notifications.success(
+            `${SocketIORequestDefaultAliasBaseEnum.NAME} request saved successfully.`,
+          );
+        }
       }
     }
   };

--- a/packages/@sparrow-workspaces/src/features/socketio-explorer/layout/SocketIoExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/socketio-explorer/layout/SocketIoExplorer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Loader } from "@sparrow/library/ui";
+  import { Loader, notifications } from "@sparrow/library/ui";
   import { Modal } from "@sparrow/library/ui";
   import { Splitpanes, Pane } from "svelte-splitpanes";
 
@@ -35,6 +35,8 @@
   import { writable } from "svelte/store";
   import { SocketSectionEnum } from "@sparrow/common/types/workspace/socket-io-request-tab";
   import { loadingState } from "../../../../../@sparrow-common/src/store";
+  import { onDestroy, onMount } from "svelte";
+  import { SocketIORequestDefaultAliasBaseEnum } from "@sparrow/common/types/workspace/socket-io-request-base";
 
   export let tab: Observable<Tab>;
   export let collections: Observable<any[]>;
@@ -85,6 +87,31 @@
     } else {
       loading.set(tabIdValue);
     }
+  });
+
+  const handleKeydown = async (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      event.preventDefault();
+      const x = await onSaveSocket();
+      if (
+        x.status === "error" &&
+        x.message === "request is not a part of any workspace or collection"
+      ) {
+        toggleSaveRequest(true);
+      } else if (x.status === "success") {
+        notifications.success(
+          `${SocketIORequestDefaultAliasBaseEnum.NAME} request saved successfully.`,
+        );
+      }
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", handleKeydown);
   });
 </script>
 

--- a/packages/@sparrow-workspaces/src/features/workspace-explorer/components/workspace-header/WorkspaceHeader.svelte
+++ b/packages/@sparrow-workspaces/src/features/workspace-explorer/components/workspace-header/WorkspaceHeader.svelte
@@ -3,6 +3,7 @@
   import { Input } from "@sparrow/library/forms";
   import { Button } from "@sparrow/library/ui";
   import { PeopleRegular, SaveRegular } from "@sparrow/library/icons";
+  import { onDestroy, onMount } from "svelte";
   /**
    * The name of the workspace.
    */
@@ -47,6 +48,27 @@
   export let onSaveWorkspace;
 
   export let isSaved;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      event.preventDefault();
+      if (
+        userRole !== WorkspaceRole.WORKSPACE_VIEWER &&
+        !isSaved &&
+        onSaveWorkspace
+      ) {
+        onSaveWorkspace();
+      }
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeyDown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", handleKeyDown);
+  });
 </script>
 
 <section>


### PR DESCRIPTION
### Description
Resolved UX issue where the `Ctrl+S` / `Cmd+S` save shortcut did not trigger the save action across several sections including:
- Collection
- Workspace
- Environment
- WebSocket
- Socket.IO

### Add Issue Number
Fixes #<your_issue_number>

### Add Screenshots/GIFs

https://github.com/user-attachments/assets/3b0158d4-d61c-46c7-b556-9c3ea13f2076



### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.