### PR TITLE
fix: auto-scroll issue on macOS when adding key-value pair

### DIFF
--- a/packages/@sparrow-workspaces/src/components/tabular-input/TabularInput.svelte
+++ b/packages/@sparrow-workspaces/src/components/tabular-input/TabularInput.svelte
@@ -5,7 +5,7 @@
   } from "@sparrow/common/interfaces/request.interface";
   import { TabularInputTheme } from "../../utils";
   import { CodeMirrorInput } from "../";
-  import { onMount, tick } from "svelte";
+  import { onMount } from "svelte";
   import { Tooltip } from "@sparrow/library/ui";
   import { Checkbox } from "@sparrow/library/forms";
   import { ErrorInfoIcon, Information } from "@sparrow/library/icons";
@@ -80,15 +80,14 @@
    * Scrolls the container to bring the newly added row into view
    */
   const scrollToNewRow = async () => {
-    await tick();
-
-    if (pairsContainer) {
-      const lastRow = pairsContainer.lastElementChild;
-
-      if (lastRow) {
-        lastRow.scrollIntoView({ behavior: "smooth", block: "end" });
+    setTimeout(() => {
+      if (pairsContainer) {
+        const lastRow = pairsContainer.lastElementChild;
+        if (lastRow) {
+          lastRow.scrollIntoView({ behavior: "smooth", block: "end" });
+        }
       }
-    }
+    }, 0);
   };
 
   const updateParam = async (index: number): Promise<void> => {

--- a/packages/@sparrow-workspaces/src/components/tabular-input/TabularInputFormData.svelte
+++ b/packages/@sparrow-workspaces/src/components/tabular-input/TabularInputFormData.svelte
@@ -11,7 +11,7 @@
   import { TabularInputTheme } from "../../utils";
   import { CodeMirrorInput } from "..";
   import { Button, Tooltip } from "@sparrow/library/ui";
-  import { onMount, tick } from "svelte";
+  import { onMount } from "svelte";
   import { Base64Converter } from "@sparrow/common/utils";
   import { Checkbox } from "@sparrow/library/forms";
   export let keyValue: {
@@ -72,15 +72,14 @@
    * Scrolls the container to bring the newly added row into view
    */
   const scrollToNewRow = async () => {
-    await tick();
-
-    if (pairsContainer) {
-      const lastRow = pairsContainer.lastElementChild;
-
-      if (lastRow) {
-        lastRow.scrollIntoView({ behavior: "smooth", block: "end" });
+    setTimeout(() => {
+      if (pairsContainer) {
+        const lastRow = pairsContainer.lastElementChild;
+        if (lastRow) {
+          lastRow.scrollIntoView({ behavior: "smooth", block: "end" });
+        }
       }
-    }
+    }, 0);
   };
 
   const updateParam = async (index: number): Promise<void> => {
@@ -287,7 +286,10 @@
   >
     {#if pairs}
       {#each pairs as element, index}
-        <div class="pair-data-row w-100 d-flex align-items-center px-1" style="position:relative">
+        <div
+          class="pair-data-row w-100 d-flex align-items-center px-1"
+          style="position:relative"
+        >
           <!-- <div class="button-container">
             <Button
               size="extra-small"
@@ -308,19 +310,22 @@
           </div>
 
           <div class="d-flex gap-0" style="width: calc(100% - 86px);">
-            <div class="w-50 d-flex align-items-center" >
-              <div class="position-absolute top-0" style="width: calc(50% - 48px);">
+            <div class="w-50 d-flex align-items-center">
+              <div
+                class="position-absolute top-0"
+                style="width: calc(50% - 48px);"
+              >
                 <CodeMirrorInput
-                bind:value={element.key}
-                onUpdateInput={() => {
-                  updateParam(index);
-                }}
-                disabled={!isInputBoxEditable ? true : false}
-                placeholder={"Add Key"}
-                {theme}
-                {environmentVariables}
-                {onUpdateEnvironment}
-              />
+                  bind:value={element.key}
+                  onUpdateInput={() => {
+                    updateParam(index);
+                  }}
+                  disabled={!isInputBoxEditable ? true : false}
+                  placeholder={"Add Key"}
+                  {theme}
+                  {environmentVariables}
+                  {onUpdateEnvironment}
+                />
               </div>
             </div>
             {#if element.type === "file"}
@@ -351,18 +356,21 @@
               </div>
             {:else}
               <div class="w-50 d-flex align-items-center">
-                <div class="position-absolute top-0 left-6" style="width: calc(50% - 48px);">
-                      <CodeMirrorInput
-                  bind:value={element.value}
-                  onUpdateInput={() => {
-                    updateParam(index);
-                  }}
-                  placeholder={"Add Value"}
-                  disabled={!isInputBoxEditable ? true : false}
-                  {theme}
-                  {environmentVariables}
-                  {onUpdateEnvironment}
-                />
+                <div
+                  class="position-absolute top-0 left-6"
+                  style="width: calc(50% - 48px);"
+                >
+                  <CodeMirrorInput
+                    bind:value={element.value}
+                    onUpdateInput={() => {
+                      updateParam(index);
+                    }}
+                    placeholder={"Add Value"}
+                    disabled={!isInputBoxEditable ? true : false}
+                    {theme}
+                    {environmentVariables}
+                    {onUpdateEnvironment}
+                  />
                 </div>
               </div>
             {/if}


### PR DESCRIPTION
### Description
Fixed auto-scroll issue when adding key-value pairs in Params and Headers. It was working on Windows but not on macOS — now works consistently across both platforms.

### Add Issue Number
Fixes #<[1518](https://github.com/sparrowapp-dev/sparrow-app/issues/1518)>

### Add Screenshots/GIFs
If applicable, add relavent screenshot/gif here.

### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.