### PR TITLE
fix: disable like dislike for empty messages

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/RestExplorer/RestExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/RestExplorer/RestExplorerPage.ViewModel.ts
@@ -2554,6 +2554,16 @@ class RestExplorerViewModel {
   public stopGeneratingAIResponse = async () => {
     const componentData = this._tab.getValue();
 
+    // Handling the case where user clicked stop generating just after the "start" stream status
+    const conversation = componentData?.property?.request?.ai?.conversations || [];
+    if(conversation.length > 0){
+      // Remove last message
+      const lastResponse = conversation[conversation.length-1];
+      if(lastResponse.type === "Receiver" && lastResponse?.message === ''){  
+        conversation.pop();
+        await this.updateRequestAIConversation(conversation);
+      }
+    }
 
     try {
       // Send stop signal to the server

--- a/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
@@ -316,31 +316,29 @@
         <Splitpanes class="explorer-chatbot-splitter">
           <Pane class="position-relative bg-transparent">
             <!--Disabling the Quick Help feature, will be taken up in next release-->
-            <div>
-              {#if isPopoverContainer}
-                <Popover
-                  onClose={closeCollectionHelpText}
-                  heading={`Welcome to Sparrow`}
-                >
-                  <p class="mb-0 text-fs-12">
-                    Your one-stop solution for API testing and management. Start
-                    organizing your API requests into collections, utilize
-                    environment variables, and streamline your development
-                    process. Get started now by creating your first collection
-                    or exploring our features
-                    <span
-                      on:click={() => {
-                        isGuidePopup = true;
-                      }}
-                      class="link p-0 border-0"
-                      style="font-size: 12px;"
-                      >See how it works.
-                    </span>
-                  </p>
-                </Popover>
-              {/if}
-            </div>
-            <div class="pt-2"></div>
+            {#if isPopoverContainer}
+              <Popover
+                onClose={closeCollectionHelpText}
+                heading={`Welcome to Sparrow`}
+              >
+                <p class="mb-0 text-fs-12">
+                  Your one-stop solution for API testing and management. Start
+                  organizing your API requests into collections, utilize
+                  environment variables, and streamline your development
+                  process. Get started now by creating your first collection or
+                  exploring our features
+                  <span
+                    on:click={() => {
+                      isGuidePopup = true;
+                    }}
+                    class="link p-0 border-0"
+                    style="font-size: 12px;"
+                    >See how it works.
+                  </span>
+                </p>
+              </Popover>
+              <div class="pt-2"></div>
+            {/if}
 
             {#if !isLoading}
               <Splitpanes


### PR DESCRIPTION
### Description
Bug Fix:
1. Disabling the chat item like/dislike action buttons for desktop version
2. Refactored the quick help banner

### Add Screenshots/GIFs
<img width="959" alt="image" src="https://github.com/user-attachments/assets/49e83298-0d57-4075-acf2-6bbbbceea542" />

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**