### PR TITLE
fix: fixed extra spacing on preview code block

### DIFF
--- a/packages/@sparrow-workspaces/src/features/chat-bot/components/ai-chat-interface/AIChatInterface.svelte
+++ b/packages/@sparrow-workspaces/src/features/chat-bot/components/ai-chat-interface/AIChatInterface.svelte
@@ -56,6 +56,8 @@
   let codeBlockHtml = ""; // will hold HTML string for preview
 
   const handleCodePreview = async (codeBlock: HTMLElement) => {
+    const codeBlockTag = codeBlock.querySelector("code.hljs") as HTMLElement;
+    if (codeBlockTag) codeBlockTag.style.maxWidth = "100%";
     codeBlockHtml = codeBlock.outerHTML; // get its full HTML
     isCodePreviewOpened = true;
 

--- a/packages/@sparrow-workspaces/src/features/chat-bot/components/chat-item/ChatItem.svelte
+++ b/packages/@sparrow-workspaces/src/features/chat-bot/components/chat-item/ChatItem.svelte
@@ -155,18 +155,19 @@
    * @param event - The mouse event triggered by clicking on the wrapper.
    */
   const handleCodePreview = async (event: MouseEvent) => {
-    const wrapper = (event.target as HTMLElement).closest(
-      ".wrapper",
-    ) as HTMLElement | null;
-
+    const wrapper = (event.target as HTMLElement).closest(".wrapper");
     if (!wrapper) return;
 
-    const preElement = wrapper.querySelector("pre > code")
-      ?.parentElement as HTMLPreElement | null;
+    const originalCodeBlock = wrapper.querySelector("pre > code.hljs");
+    const originalPreElement = originalCodeBlock?.parentElement;
 
-    if (preElement) {
-      onClickCodeBlockPreview(preElement);
-    }
+    if (!originalCodeBlock || !originalPreElement) return;
+
+    const preClone = originalPreElement.cloneNode(true) as HTMLPreElement;
+    const clonedCodeBlock = preClone.querySelector("code.hljs") as HTMLElement;
+
+    clonedCodeBlock.style.maxWidth = "100%";
+    onClickCodeBlockPreview(preClone);
   };
 
   /**

--- a/packages/@sparrow-workspaces/src/features/chat-bot/components/chat-item/ChatItem.svelte
+++ b/packages/@sparrow-workspaces/src/features/chat-bot/components/chat-item/ChatItem.svelte
@@ -157,16 +157,10 @@
   const handleCodePreview = async (event: MouseEvent) => {
     const wrapper = (event.target as HTMLElement).closest(".wrapper");
     if (!wrapper) return;
-
     const originalCodeBlock = wrapper.querySelector("pre > code.hljs");
     const originalPreElement = originalCodeBlock?.parentElement;
-
     if (!originalCodeBlock || !originalPreElement) return;
-
     const preClone = originalPreElement.cloneNode(true) as HTMLPreElement;
-    const clonedCodeBlock = preClone.querySelector("code.hljs") as HTMLElement;
-
-    clonedCodeBlock.style.maxWidth = "100%";
     onClickCodeBlockPreview(preClone);
   };
 


### PR DESCRIPTION
### Description
Extra space was coming on the right side of the code preview popup. Fixed by resizing the max-width. This issue was occurring in the larger screen sizes.

### Add Screenshots/GIFs
Before
<img width="690" alt="image" src="https://github.com/user-attachments/assets/a63fb29e-c7d3-4535-b9a0-d67fa1a6057d" />

After
<img width="685" alt="image" src="https://github.com/user-attachments/assets/e5829a4e-6c5a-4ee3-b6f7-9e11ee7beb3a" />

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**
