### PR TITLE
Fix: Testflow reponse button gap issue.

### DIFF
--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/components/response-body-navigator/ResponseBodyNavigator.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/components/response-body-navigator/ResponseBodyNavigator.svelte
@@ -112,7 +112,7 @@
     class="response-container d-flex align-items-center pb-1 px-0 justify-content-between w-100 z-1 position-sticky"
     style="top:55.4px;  margin-top: -1px;"
   >
-    <div class="d-flex gap-3 align-items-center justify-content-center">
+    <div class="d-flex gap-1 align-items-center justify-content-center">
       <div class="d-flex align-items-center rounded mb-0 py-1">
         <span
           role="button"
@@ -121,7 +121,7 @@
               responseBodyFormatter: ResponseFormatter.PRETTY,
             });
           }}
-          class="rounded text-fs-12 border-radius-2 px-3 me-3 py-1 btn-formatter {apiState.responseBodyFormatter ===
+          class="rounded text-fs-12 border-radius-2 px-3 me-1 py-1 btn-formatter {apiState.responseBodyFormatter ===
           ResponseFormatter.PRETTY
             ? 'bg-tertiary-500 text-secondary-100'
             : ''}"


### PR DESCRIPTION
### Description
I have updated the gap between the response button's.

### Add Issue Number
Fixes # SPRW-653

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/099367ee-d1db-4e44-abc8-e275c47cf8c1)

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**