### PR TITLE
fix: fixed the hubs heading [SPRW-693]

### DIFF
--- a/packages/@sparrow-teams/src/features/team-list/layout/TeamList.svelte
+++ b/packages/@sparrow-teams/src/features/team-list/layout/TeamList.svelte
@@ -9,7 +9,7 @@
     PeopleFilled,
     PeopleRegular,
   } from "@sparrow/library/icons";
-  import {policyConfig} from "@sparrow/common/store"
+  import { policyConfig } from "@sparrow/common/store";
   export let isCreateTeamModalOpen;
   export let isGuestUser;
   export let setOpenTeam;
@@ -28,7 +28,7 @@
       class="teams-heading px-1 text-ds-font-size-14 text-ds-line-height-143 text-ds-font-weight-regular"
       style=" color:var(--bg-ds-neutral-300); display:flex;align-items:center; margin-bottom:0;"
     >
-      Sparrow Hubs
+      Hubs
     </h6>
     {#if $policyConfig.hubCreationAllowed}
       <div>

--- a/packages/@sparrow-teams/src/features/team-sidepanel/layout/TeamSidePanel.svelte
+++ b/packages/@sparrow-teams/src/features/team-sidepanel/layout/TeamSidePanel.svelte
@@ -84,7 +84,7 @@
         <div
           class="sidebar-teams-header d-flex justify-content-between p-3 pb-0"
         >
-          <h6 class="teams-heading ms-2 px-1">Sparrow Hubs</h6>
+          <h6 class="teams-heading ms-2 px-1">Hubs</h6>
           <div>
             <Tooltip title="New Hub" placement={"bottom-center"} distance={10}>
               <button

--- a/packages/@sparrow-teams/src/features/team-sidepanel/layout/TeamSidePanel.svelte
+++ b/packages/@sparrow-teams/src/features/team-sidepanel/layout/TeamSidePanel.svelte
@@ -84,7 +84,7 @@
         <div
           class="sidebar-teams-header d-flex justify-content-between p-3 pb-0"
         >
-          <h6 class="teams-heading ms-2 px-1">Hubs</h6>
+          <h6 class="teams-heading ms-2 px-1">Sparrow Hubs</h6>
           <div>
             <Tooltip title="New Hub" placement={"bottom-center"} distance={10}>
               <button


### PR DESCRIPTION
### Description
Fixed the sparrow hubs heading to "Hubs"

![image](https://github.com/user-attachments/assets/615102c4-a134-4453-92d7-3e36f2015e09)


### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.