### PR TITLE
fix: sparrow release timeline url

### DIFF
--- a/packages/@sparrow-support/src/features/release-notes/layout/ReleaseNotes.svelte
+++ b/packages/@sparrow-support/src/features/release-notes/layout/ReleaseNotes.svelte
@@ -180,6 +180,25 @@
     filteredEvents = events;
     isLoading = false;
   });
+
+  const renderer = new marked.Renderer();
+  renderer.link = function (href, title, text) {
+    let url = href;
+    if (typeof href === "object" && href !== null) {
+      url = href.href || href.raw || href.text || "#";
+    }
+
+    url = String(url);
+    let linkText = text;
+    if (typeof text === "object" && text !== null) {
+      linkText = text.text || text.raw || "Link";
+    }
+
+    linkText = linkText !== undefined ? String(linkText) : "Link";
+    return `<a href="${url}"${title ? ` title="${title}"` : ""} target="_blank" rel="noopener noreferrer">${url}</a>`;
+  };
+
+  marked.setOptions({ renderer });
 </script>
 
 <div style="height:100%; width:100%;">

--- a/packages/@sparrow-support/src/features/release-notes/layout/ReleaseNotes.svelte
+++ b/packages/@sparrow-support/src/features/release-notes/layout/ReleaseNotes.svelte
@@ -181,6 +181,7 @@
     isLoading = false;
   });
 
+  // Render URL in web
   const renderer = new marked.Renderer();
   renderer.link = function (href, title, text) {
     let url = href;


### PR DESCRIPTION
### Description
The URL in releases in timeline section is now opening in web instead of desktop app.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.