### PR TITLE
fix: The secondary button outline shifts position when hovering SPRW-1074.

### DIFF
--- a/packages/@sparrow-library/src/ui/button/Button.svelte
+++ b/packages/@sparrow-library/src/ui/button/Button.svelte
@@ -341,7 +341,7 @@
   }
   .custom-btn-outline-secondary:hover {
     background-color: var(--bg-ds-surface-300);
-    border: 0px;
+    border: 1px solid var(--border-ds-surface-300);
     color: var(--text-ds-neutral-50);
   }
   .custom-btn-outline-secondary:focus-visible {
@@ -351,7 +351,7 @@
   }
   .custom-btn-outline-secondary:active {
     background-color: var(--bg-ds-surface-400);
-    border: 0px;
+    border: 1px solid var(--border-ds-surface-400);
     color: var(--text-ds-neutral-50);
   }
   .custom-btn-outline-secondary-disable {


### PR DESCRIPTION
### Description
 have added a border on hover to prevent the position from shifting when the border is removed.

### Add Issue Number
Fixes #jira

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/534d3fa4-9aaa-4a06-96de-7a70afcd1010)

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**