### PR TITLE
fix: Error message referring to run blocks in Dynamic expression SPRW-1071

### DIFF
--- a/packages/@sparrow-workspaces/src/features/testflow-dynamic-expressions/components/expression-editor/ExpressionEditor.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-dynamic-expressions/components/expression-editor/ExpressionEditor.svelte
@@ -10,6 +10,7 @@
   export let selectedApiRequestType: string;
   export let onPreviewExpression;
   export let dispatcher;
+  export let runDynamicExpression: boolean = false;
 
   let expressionPreviewResult = "";
   let expressionErrorResult = "";
@@ -156,7 +157,9 @@
         class="text-fs-12 mb-0 ellipsis-5"
         style="color: var(--text-ds-danger-300)"
       >
-        No preview available. Please check your expression and try again.
+        {runDynamicExpression
+          ? "No preview available. Please check your expression and try again."
+          : "Please run the Blocks to check the dynamic expression preview."}
       </p>
     {/if}
   </div>

--- a/packages/@sparrow-workspaces/src/features/testflow-dynamic-expressions/layout/TestflowDynamicExpression.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-dynamic-expressions/layout/TestflowDynamicExpression.svelte
@@ -19,6 +19,7 @@
   export let edges;
   export let onPreviewExpression;
   export let dynamicExpressionPath: string = "";
+  export let runDynamicExpression: boolean = false;
 
   let dispatcher;
 
@@ -110,6 +111,7 @@
       {onPreviewExpression}
       {handleAddingNested}
       bind:selectedApiRequestType
+      {runDynamicExpression}
       bind:dispatcher
     />
   </div>

--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
@@ -1714,6 +1714,7 @@
     {environmentVariables}
     {onPreviewExpression}
     {dynamicExpressionPath}
+    runDynamicExpression={testflowStore?.history.length > 0 ? true : false}
   />
 </Modal>
 


### PR DESCRIPTION
### Description
I have added a condition where, if the user has not run the blocks to preview the dynamic expression (DE), they will receive a proper error message prompting them to run the blocks.

### Add Issue Number
Fixes #jira

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/550a666b-408b-4ec6-944e-2063c28422c0)

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**