### PR TITLE
fix: restricted to open orphan data from global search [SPRW-1155]

### DIFF
--- a/apps/@sparrow-desktop/src/pages/teams-page/Teams.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/teams-page/Teams.ViewModel.ts
@@ -19,6 +19,8 @@ import MixpanelEvent from "@app/utils/mixpanel/MixpanelEvent";
 import { Events } from "@sparrow/common/enums";
 import { WorkspaceService } from "@app/services/workspace.service";
 import { WorkspaceTabAdapter } from "@app/adapter/workspace-tab";
+import { EnvironmentRepository } from "@app/repositories/environment.repository";
+import { TestflowRepository } from "@app/repositories/testflow.repository";
 
 export class TeamsViewModel {
   constructor() {}
@@ -33,6 +35,8 @@ export class TeamsViewModel {
 
   private collectionRepository = new CollectionRepository();
   private userService = new UserService();
+  private environmentRepository = new EnvironmentRepository();
+  private testflowRepository = new TestflowRepository();
 
   /**
    * @description - get environment list from local db
@@ -353,11 +357,23 @@ export class TeamsViewModel {
         data.push(item);
       }
       await this.workspaceRepository.bulkInsertData(data);
-      await this.workspaceRepository.deleteOrphanWorkspaces(
-        data.map((_workspace) => {
-          return _workspace._id;
-        }),
-      );
+      const selectedWorkspacesToBeDeleted =
+        await this.workspaceRepository.deleteOrphanWorkspaces(
+          data.map((_workspace) => {
+            return _workspace._id;
+          }),
+        );
+      if (selectedWorkspacesToBeDeleted?.length > 0) {
+        await this.collectionRepository.removeCollectionsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+        await this.environmentRepository.removeEnvironmentsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+        await this.testflowRepository.removeTestflowsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+      }
       const isSharedWorkspaceActive =
         await this.workspaceRepository.getSharedPublicActiveWorkspace();
       if (!isAnyWorkspaceActive && !isSharedWorkspaceActive) {

--- a/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/CollectionsPage.svelte
@@ -996,7 +996,7 @@
       }}
       disabled={false}
     />
-    <p class="m-0">I understand, don't show this agian.</p>
+    <p class="m-0">I understand, don't show this again.</p>
   </div>
 
   <div

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/RestExplorerMockPage/RestExplorerMockPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/RestExplorerMockPage/RestExplorerMockPage.ViewModel.ts
@@ -1040,6 +1040,15 @@ class RestExplorerMockViewModel {
    */
   public sendRequest = async (environmentVariables = []) => {
     const progressiveTab: Tab = createDeepCopy(this._tab.getValue());
+    const collectionData = await this.collectionRepository.readCollection(
+      progressiveTab.path.collectionId,
+    );
+    if (!collectionData?.isMockCollectionRunning) {
+      notifications.error(
+        "Mock collection is inactive. Activate it to try the request.",
+      );
+      return;
+    }
     const initRequestTab = new InitTab().request(
       UntrackedItems.UNTRACKED + uuidv4(),
       progressiveTab.path.workspaceId,

--- a/apps/@sparrow-desktop/src/repositories/collection.repository.ts
+++ b/apps/@sparrow-desktop/src/repositories/collection.repository.ts
@@ -942,4 +942,22 @@ export class CollectionRepository {
 
     return node ?? null;
   };
+
+  /* Remove collections by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter collections
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeCollectionsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb?.collection.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
+  };
 }

--- a/apps/@sparrow-desktop/src/repositories/environment.repository.ts
+++ b/apps/@sparrow-desktop/src/repositories/environment.repository.ts
@@ -154,7 +154,9 @@ export class EnvironmentRepository {
       .exec();
   };
 
-    public searchEnvironments = async (searchQuery: string): Promise<EnvironmentDocument[]> => {
+  public searchEnvironments = async (
+    searchQuery: string,
+  ): Promise<EnvironmentDocument[]> => {
     if (!searchQuery.trim()) {
       // If search query is empty, return recently updated environments
       return await RxDB.getInstance()
@@ -178,7 +180,6 @@ export class EnvironmentRepository {
       .exec();
   };
 
-
   public getRecentEnvironments = async (): Promise<EnvironmentDocument[]> => {
     return await RxDB.getInstance()
       .rxdb.environment.find({
@@ -186,6 +187,22 @@ export class EnvironmentRepository {
       })
       .exec();
   };
+
+  /* Remove environments by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter environments
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeEnvironmentsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb.environment.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
+  };
 }
-
-

--- a/apps/@sparrow-desktop/src/repositories/testflow.repository.ts
+++ b/apps/@sparrow-desktop/src/repositories/testflow.repository.ts
@@ -168,18 +168,18 @@ export class TestflowRepository {
   };
 
   public searchTestflows = async (
-    _query: string
+    _query: string,
   ): Promise<TFRxHandlerType[] | undefined> => {
     const testflows = await this.rxdb
       ?.find({
         selector: {
           name: {
-            $regex: new RegExp(_query, 'i')
-          }
-        }
+            $regex: new RegExp(_query, "i"),
+          },
+        },
       })
       .exec();
-    
+
     return testflows;
   };
 
@@ -189,13 +189,32 @@ export class TestflowRepository {
    * @param _limit - The maximum number of test flows to return (defaults to 5).
    * @returns A promise that resolves to an array of the most recent test flow documents.
    */
-  public getRecentTestflows = async (
-  ): Promise<TFRxHandlerType[] | undefined> => {
+  public getRecentTestflows = async (): Promise<
+    TFRxHandlerType[] | undefined
+  > => {
     const testflows = await this.rxdb
       ?.find()
-      .sort({ updatedAt: 'desc' })
+      .sort({ updatedAt: "desc" })
       .exec();
-    
+
     return testflows;
+  };
+
+  /* Remove testflows by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter testflows
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeTestflowsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb?.testflow.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
   };
 }

--- a/apps/@sparrow-desktop/src/repositories/workspace.repository.ts
+++ b/apps/@sparrow-desktop/src/repositories/workspace.repository.ts
@@ -335,6 +335,7 @@ export class WorkspaceRepository {
         selectedWorkspacesToBeDeleted as string[],
       );
     }
+    return selectedWorkspacesToBeDeleted;
   };
 
   public updateUserRoleInWorkspace = async (

--- a/apps/@sparrow-web/src/pages/Dashboard/Dashboard.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/Dashboard/Dashboard.ViewModel.ts
@@ -33,6 +33,7 @@ import { v4 as uuidv4 } from "uuid";
 import {
   CollectionTabAdapter,
   GraphqlTabAdapter,
+  RequestMockTabAdapter,
   RequestTabAdapter,
   SocketIoTabAdapter,
   TestflowTabAdapter,
@@ -674,6 +675,17 @@ export class DashboardViewModel {
         await this.tabRepository.createTab(adaptedSocketIo, workspaceId);
         break;
       }
+      case "MOCK_REQUEST": {
+        const mockRequestTabAdapter = new RequestMockTabAdapter();
+        const adaptedMockRequest = mockRequestTabAdapter.adapt(
+          workspaceId,
+          collectionId,
+          folderId,
+          tree,
+        );
+        await this.tabRepository.createTab(adaptedMockRequest, workspaceId);
+        break;
+      }
       default: {
         const requestTabAdapter = new RequestTabAdapter();
         const adaptedRequest = requestTabAdapter.adapt(
@@ -814,6 +826,8 @@ export class DashboardViewModel {
         return tree.websocket?.url || "";
       case ItemType.REQUEST:
         return tree.request?.url || "";
+      case ItemType.MOCK_REQUEST:
+        return tree.mockRequest?.url || "";
       default:
         return "";
     }
@@ -869,6 +883,7 @@ export class DashboardViewModel {
     if (tree.name.toLowerCase().includes(searchText.toLowerCase())) {
       if (
         tree.type === ItemType.REQUEST ||
+        tree.type === ItemType.MOCK_REQUEST ||
         tree.type === ItemType.GRAPHQL ||
         tree.type === ItemType.SOCKET_IO ||
         tree.type === ItemType.WEB_SOCKET
@@ -881,7 +896,11 @@ export class DashboardViewModel {
               : folderDetails;
 
         const requestMethod =
-          tree.type === ItemType.REQUEST ? tree.request?.method : tree.type;
+          tree.type === ItemType.REQUEST
+            ? tree.request?.method
+            : tree.type === ItemType.MOCK_REQUEST
+              ? tree.mockRequest?.method
+              : tree.type;
 
         const requestData = {
           tree: JSON.parse(
@@ -917,6 +936,7 @@ export class DashboardViewModel {
         tree.type !== ItemType.FOLDER &&
         !Object.values([
           ItemType.REQUEST,
+          ItemType.MOCK_REQUEST,
           ItemType.GRAPHQL,
           ItemType.SOCKET_IO,
           ItemType.WEB_SOCKET,
@@ -1009,7 +1029,11 @@ export class DashboardViewModel {
       const workspaceId = node.workspaceId || currentWorkspaceId;
 
       const requestMethod =
-        node.type === ItemType.REQUEST ? node.request?.method : node.type;
+        node.type === ItemType.REQUEST
+          ? node.request?.method
+          : node.type === ItemType.MOCK_REQUEST
+            ? node.mockRequest?.method
+            : node.type;
 
       const itemData = {
         tree: JSON.parse(
@@ -1029,6 +1053,7 @@ export class DashboardViewModel {
         type: node.type,
         folderDetails: [
           ItemType.REQUEST,
+          ItemType.MOCK_REQUEST,
           ItemType.SOCKET_IO,
           ItemType.WEB_SOCKET,
           ItemType.GRAPHQL,
@@ -1044,6 +1069,7 @@ export class DashboardViewModel {
         case ItemType.REQUEST:
         case ItemType.SOCKET_IO:
         case ItemType.WEB_SOCKET:
+        case ItemType.MOCK_REQUEST:
         case ItemType.GRAPHQL:
           requests.push(itemData);
           break;
@@ -1199,7 +1225,7 @@ export class DashboardViewModel {
 
     let environment = await this.searchEnvironment(searchText);
     environment = environment.map((_environment) => {
-      const workspaceDetails = workspaceMap[_value._data.workspaceId];
+      const workspaceDetails = workspaceMap[_environment._data.workspaceId];
       const path: string[] = [];
       if (workspaceDetails) {
         path.push(workspaceDetails.teamName);

--- a/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
@@ -19,6 +19,8 @@ import MixpanelEvent from "@app/utils/mixpanel/MixpanelEvent";
 import { Events } from "@sparrow/common/enums";
 import { BehaviorSubject, Observable } from "rxjs";
 import { WorkspaceService } from "../../services/workspace.service";
+import { EnvironmentRepository } from "src/repositories/environment.repository";
+import { TestflowRepository } from "src/repositories/testflow.repository";
 
 export class TeamsViewModel {
   constructor() {}
@@ -33,6 +35,8 @@ export class TeamsViewModel {
 
   private collectionRepository = new CollectionRepository();
   private userService = new UserService();
+  private environmentRepository = new EnvironmentRepository();
+  private testflowRepository = new TestflowRepository();
   private _activeTeamTab: BehaviorSubject<string> = new BehaviorSubject(
     "Workspaces",
   );
@@ -210,11 +214,24 @@ export class TeamsViewModel {
         data.push(item);
       }
       await this.workspaceRepository.bulkInsertData(data);
-      await this.workspaceRepository.deleteOrphanWorkspaces(
-        data.map((_workspace) => {
-          return _workspace._id;
-        }),
-      );
+      const selectedWorkspacesToBeDeleted =
+        await this.workspaceRepository.deleteOrphanWorkspaces(
+          data.map((_workspace) => {
+            return _workspace._id;
+          }),
+        );
+
+      if (selectedWorkspacesToBeDeleted?.length > 0) {
+        await this.collectionRepository.removeCollectionsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+        await this.environmentRepository.removeEnvironmentsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+        await this.testflowRepository.removeTestflowsByWorkspaceIds(
+          selectedWorkspacesToBeDeleted,
+        );
+      }
       const sharedWorkspce =
         await this.workspaceRepository.findWorkspaceByTeamId(
           "sharedWorkspaceTeam",

--- a/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
+++ b/apps/@sparrow-web/src/pages/workspace-page/CollectionsPage.svelte
@@ -1051,7 +1051,7 @@
       }}
       disabled={false}
     />
-    <p class="m-0">I understand, don't show this agian.</p>
+    <p class="m-0">I understand, don't show this again.</p>
   </div>
 
   <div

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/RestExplorerMockPage/RestExplorerMockPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/RestExplorerMockPage/RestExplorerMockPage.ViewModel.ts
@@ -1044,6 +1044,15 @@ class RestExplorerMockViewModel {
       UntrackedItems.UNTRACKED + uuidv4(),
       progressiveTab.path.workspaceId,
     );
+    const collectionData = await this.collectionRepository.readCollection(
+      progressiveTab.path.collectionId,
+    );
+    if (!collectionData?.isMockCollectionRunning) {
+      notifications.error(
+        "Mock collection is inactive. Activate it to try the request.",
+      );
+      return;
+    }
     initRequestTab.updateBody(progressiveTab.property.mockRequest?.body);
     initRequestTab.updateUrl(progressiveTab.property.mockRequest?.url);
     initRequestTab.updateName(progressiveTab.name);

--- a/apps/@sparrow-web/src/repositories/collection.repository.ts
+++ b/apps/@sparrow-web/src/repositories/collection.repository.ts
@@ -937,4 +937,22 @@ export class CollectionRepository {
 
     return node ?? null;
   };
+
+  /* Remove collections by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter collections
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeCollectionsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb?.collection.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
+  };
 }

--- a/apps/@sparrow-web/src/repositories/environment.repository.ts
+++ b/apps/@sparrow-web/src/repositories/environment.repository.ts
@@ -187,4 +187,22 @@ export class EnvironmentRepository {
       })
       .exec();
   };
+
+  /* Remove environments by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter environments
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeEnvironmentsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb.environment.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
+  };
 }

--- a/apps/@sparrow-web/src/repositories/testflow.repository.ts
+++ b/apps/@sparrow-web/src/repositories/testflow.repository.ts
@@ -199,4 +199,22 @@ export class TestflowRepository {
 
     return testflows;
   };
+
+  /* Remove testflows by multiple workspaceIds
+   * @param _workspaceIds - Single workspaceId or array of workspaceIds to filter testflows
+   * @returns Promise resolving to the result of the removal operation
+   */
+  public removeTestflowsByWorkspaceIds = async (
+    _workspaceIds: string[],
+  ): Promise<any> => {
+    return await RxDB.getInstance()
+      .rxdb?.testflow.find({
+        selector: {
+          workspaceId: {
+            $in: _workspaceIds,
+          },
+        },
+      })
+      .remove();
+  };
 }

--- a/apps/@sparrow-web/src/repositories/workspace.repository.ts
+++ b/apps/@sparrow-web/src/repositories/workspace.repository.ts
@@ -335,6 +335,7 @@ export class WorkspaceRepository {
         selectedWorkspacesToBeDeleted as string[],
       );
     }
+    return selectedWorkspacesToBeDeleted;
   };
 
   public updateUserRoleInWorkspace = async (

--- a/packages/@sparrow-common/src/features/global-search/components/RecentItems/RecentItems.svelte
+++ b/packages/@sparrow-common/src/features/global-search/components/RecentItems/RecentItems.svelte
@@ -76,6 +76,13 @@
           name: request.tree.name,
           description: request.tree.description || "",
         };
+      case "MOCK_REQUEST":
+        return {
+          url: request.tree.mockRequest?.url || "",
+          method: request.tree.mockRequest?.method || "",
+          name: request.tree.name,
+          description: request.tree.description || "",
+        };
       default:
         return {
           url: request.tree.request?.url || "",


### PR DESCRIPTION
### Description
In these PR we have, 
FIxed the issue when mock api was opening as collection, 
Added removce environments, collections, and testflows with workspaceID function in repository so that when workspace is switched from public to private, the uncessary data of orphan workspaces could be removed. 

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.