### PR TITLE
Fix: response status tool tip overlapping issue SPRW-624. 

### DIFF
--- a/packages/@sparrow-workspaces/src/features/rest-explorer/components/response-status/ResponseStatus.svelte
+++ b/packages/@sparrow-workspaces/src/features/rest-explorer/components/response-status/ResponseStatus.svelte
@@ -33,7 +33,7 @@
       <div class="d-flex align-items-center gap-3">
         <Tooltip
           title="HTTP Status - {response.status}"
-          placement={"bottom-center"}
+          placement={"top-center"}
           zIndex={500}
         >
           <span
@@ -59,11 +59,7 @@
             >
           </span>
         </Tooltip>
-        <Tooltip
-          title="Time"
-          placement={"bottom-center"}
-          zIndex={500}
-        >
+        <Tooltip title="Time" placement={"top-center"} zIndex={500}>
           <span
             class="text-fs-12 d-flex align-items-center border-0 justify-content-center align-items-center rounded time-primary1 response-text"
             style=" color:{checkIfRequestSucceed(response?.status)
@@ -95,11 +91,7 @@
             </p>
           </span>
         </Tooltip>
-        <Tooltip
-          title="Size"
-          placement={"bottom-center"}
-          zIndex={500}
-        >
+        <Tooltip title="Size" placement={"top-center"} zIndex={500}>
           <span
             class="d-flex align-items-center justify-content-center rounded border-0 text-backgroundColor size-primary1 response-text"
             style="font-size: 12px;"


### PR DESCRIPTION
### Description
I have updated the tool tip position so that it does not overlap any response text. 

### Add Issue Number
Fixes #jira

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/bcf1ee03-fdb1-4ec8-a162-4e1cf26d661d)

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**