### PR TITLE
Fix: Refresh the Teams tab to ensure valid invites are visible. SPRW-796.

### DIFF
--- a/apps/@sparrow-desktop/src/pages/teams-page/sub-pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/teams-page/sub-pages/TeamExplorerPage/TeamExplorerPage.ViewModel.ts
@@ -86,8 +86,13 @@ export class TeamExplorerPageViewModel {
   /**
    * @description - Update the active team tab
    */
-  public updateActiveTeamTab = (tab: string) => {
-    this.activeTeamTab = tab;
+  public updateActiveTeamTab = async (tab: string, userId: string) => {
+    if (this._activeTeamTab.value !== tab) {
+      this._activeTeamTab.next(tab);
+      if (this._activeTeamTab.value === "Invites") {
+        await this.refreshTeams(userId);
+      }
+    }
   };
 
   /**

--- a/apps/@sparrow-desktop/src/pages/teams-page/sub-pages/TeamExplorerPage/TeamExplorerPage.svelte
+++ b/apps/@sparrow-desktop/src/pages/teams-page/sub-pages/TeamExplorerPage/TeamExplorerPage.svelte
@@ -73,6 +73,10 @@
       `${constants.SPARROW_WEB_APP_URL}/app/collections?workspaceId=${workspaceId}`,
     );
   };
+
+  const handleChangeTab = async (tab: string) => {
+    await _viewModel.updateActiveTeamTab(tab, userId);
+  };
 </script>
 
 <TeamExplorer
@@ -85,7 +89,7 @@
   workspaces={$workspaces}
   activeTeamTab={$activeTeamTab}
   onDeleteWorkspace={handleDeleteWorkspace}
-  onUpdateActiveTab={_viewModel.updateActiveTeamTab}
+  onUpdateActiveTab={handleChangeTab}
   onCreateWorkspace={_viewModel.handleCreateWorkspace}
   onSwitchWorkspace={_viewModel.handleSwitchWorkspace}
   onRemoveMembersAtTeam={_viewModel.removeMembersAtTeam}

--- a/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
@@ -53,8 +53,13 @@ export class TeamsViewModel {
   /**
    * @description - Update the active team tab
    */
-  public updateActiveTeamTab = (tab: string) => {
-    this.activeTeamTab = tab;
+  public updateActiveTeamTab = async (tab: string, userId: string) => {
+    if (this._activeTeamTab.value !== tab) {
+      this._activeTeamTab.next(tab);
+      if (this._activeTeamTab.value === "Invites") {
+        await this.refreshTeams(userId);
+      }
+    }
   };
 
   /**

--- a/apps/@sparrow-web/src/pages/Teams/Teams.svelte
+++ b/apps/@sparrow-web/src/pages/Teams/Teams.svelte
@@ -146,6 +146,10 @@
   });
 
   let isPopupOpen = false;
+
+  const handleChangeTab = async (tab: string) => {
+    await _viewModel.updateActiveTeamTab(tab, userId);
+  };
 </script>
 
 <Motion {...pagesMotion} let:motion>
@@ -279,7 +283,7 @@
       >
         <TeamExplorerPage
           activeTeamTab={$activeTeamTab}
-          onUpdateActiveTab={_viewModel.updateActiveTeamTab}
+          onUpdateActiveTab={handleChangeTab}
           bind:isPopupOpen
         />
       </Pane>


### PR DESCRIPTION
### Description
I have added refresh on Click on Tab to fetch valid Invites.

### Add Issue Number
Fixes jira

### Add Screenshots/GIFs
If applicable, add relavent screenshot/gif here.

### Add Known Issue
It resolves the issue of selecting a tab with the same name multiple times.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**