### PR TITLE
Fix: Block open default after test flow execution issue SPRW-1124.

### DIFF
--- a/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/testflow-explorer/layout/TestflowExplorer.svelte
@@ -1248,6 +1248,23 @@
   };
 
   /**
+   * This Function will the pass the value of first Node is Connected Target value.
+   */
+  const handleSelectFirstNode = () => {
+    let fisrtNode = "2";
+    edges.update((_edges) => {
+      for (let item = 0; item < _edges.length; item++) {
+        if (_edges[item]?.source === "1") {
+          fisrtNode = _edges[item]?.target;
+          break;
+        }
+      }
+      return _edges;
+    });
+    selectNode(fisrtNode);
+  };
+
+  /**
    * Focuses the div element by calling its focus method.
    */
   const focusDiv = () => {
@@ -1432,7 +1449,7 @@
                 onClick={async () => {
                   unselectNodes();
                   await onClickRun();
-                  selectNode("2");
+                  handleSelectFirstNode();
                   MixpanelEvent(Events.Run_TestFlows);
                   handleEventOnRunBlocks();
                 }}


### PR DESCRIPTION
### Description
Every time the test flow runs, the first block opens by default. I have updated it so that the block in the first position opens after execution instead.

### Add Issue Number
Fixes # jira

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/7aa46aad-d21c-48b2-af80-770582614926)

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**