### PR TITLE
fix: add gap between profile icon and right boundary [SPRW-986]

### DIFF
--- a/packages/@sparrow-common/src/components/header/Header.svelte
+++ b/packages/@sparrow-common/src/components/header/Header.svelte
@@ -480,7 +480,10 @@
 
   <div
     class="d-flex align-items-center no-drag"
-    style="position: relative; display:flex; gap: 16px;"
+    style="position: relative; display:flex; gap: 16px; margin-right: {isWebApp ||
+    !isWindows
+      ? '16px'
+      : '0px'}"
   >
     {#if isGuestUser && isLoginBannerActive === false && $policyConfig.enableLogin}
       <Tooltip
@@ -663,7 +666,7 @@
     {/if}
 
     {#if !isGuestUser}
-      <div class={"pe-1"}>
+      <div>
         <UserProfileModal
           {isGuestUser}
           item={sidebarModalItem}


### PR DESCRIPTION
### Description
Add spacing between profile icon and right boundary [SPRW-986].

### Add Screenshots/GIFs
![image](https://github.com/user-attachments/assets/a0537c86-c660-45f4-ae50-279d63badc46)

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

[SPRW-986]: https://techdome.atlassian.net/browse/SPRW-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ