### PR TITLE
fix: removed base url in tab creation []

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
@@ -868,7 +868,7 @@ class CollectionExplorerPage {
       totalFolders,
       lastUpdated,
       totalMockRequests,
-      totalAiRequests
+      totalAiRequests,
     };
   };
 
@@ -1170,7 +1170,7 @@ class CollectionExplorerPage {
         description: "",
         mockRequest: {
           method: request?.getValue().property?.mockRequest?.method,
-          url: collection?.mockCollectionUrl,
+          url: "",
         } as HttpRequestBaseInterface,
       },
     };
@@ -1232,7 +1232,7 @@ class CollectionExplorerPage {
         folderId: "",
       });
       request.updateIsSave(true);
-      request.updateUrl(collection?.mockCollectionUrl);
+      // request.updateUrl(collection?.mockCollectionUrl);
       this.tabRepository.createTab(request.getValue());
       moveNavigation("right");
       return;
@@ -1278,8 +1278,10 @@ class CollectionExplorerPage {
         type: aiRequest.getValue().type,
         description: "",
         aiRequest: {
-          aiModelProvider: aiRequest?.getValue().property?.aiRequest?.aiModelProvider,
-          aiModelVariant: aiRequest?.getValue().property?.aiRequest?.aiModelVariant,
+          aiModelProvider:
+            aiRequest?.getValue().property?.aiRequest?.aiModelProvider,
+          aiModelVariant:
+            aiRequest?.getValue().property?.aiRequest?.aiModelVariant,
         } as AiRequestBaseInterface,
       },
     };

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
@@ -19,7 +19,7 @@ import {
   InitMockRequestTab,
   InitWebSocketTab,
   moveNavigation,
-  InitAiRequestTab
+  InitAiRequestTab,
 } from "@sparrow/common/utils";
 import { Events, ItemType, UntrackedItems } from "@sparrow/common/enums";
 // import { invoke } from "@tauri-apps/api/core";
@@ -325,7 +325,7 @@ class FolderExplorerPage {
       totalSocketIo,
       totalWebSocket,
       totalMockRequests,
-      totalAiRequests
+      totalAiRequests,
     };
   };
 
@@ -505,7 +505,7 @@ class FolderExplorerPage {
           description: "",
           mockRequest: {
             method: sampleRequest.getValue().property.mockRequest?.method,
-            url: collection?.mockCollectionUrl,
+            url: "",
           },
         },
       },
@@ -575,7 +575,7 @@ class FolderExplorerPage {
         folderId: explorer.id,
       });
       sampleRequest.updateIsSave(true);
-      sampleRequest.updateUrl(collection?.mockCollectionUrl);
+      // sampleRequest.updateUrl(collection?.mockCollectionUrl);
       this.tabRepository.createTab(sampleRequest.getValue());
 
       moveNavigation("right");
@@ -968,8 +968,10 @@ class FolderExplorerPage {
           type: aiRequest.getValue().type,
           description: "",
           aiRequest: {
-            aiModelProvider: aiRequest.getValue().property.aiRequest?.aiModelProvider,
-            aiModelVariant: aiRequest.getValue().property.aiRequest?.aiModelVariant,
+            aiModelProvider:
+              aiRequest.getValue().property.aiRequest?.aiModelProvider,
+            aiModelVariant:
+              aiRequest.getValue().property.aiRequest?.aiModelVariant,
           },
         },
       },

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/CollectionExplorerPage/CollectionExplorerPage.ViewModel.ts
@@ -867,7 +867,7 @@ class CollectionExplorerPage {
       totalFolders,
       lastUpdated,
       totalMockRequests,
-      totalAiRequests
+      totalAiRequests,
     };
   };
 
@@ -1168,7 +1168,7 @@ class CollectionExplorerPage {
         description: "",
         mockRequest: {
           method: request?.getValue().property?.mockRequest?.method,
-          url: collection?.mockCollectionUrl,
+          url: "",
         } as HttpRequestBaseInterface,
       },
     };
@@ -1230,7 +1230,7 @@ class CollectionExplorerPage {
         folderId: "",
       });
       request.updateIsSave(true);
-      request.updateUrl(collection?.mockCollectionUrl);
+      // request.updateUrl(collection?.mockCollectionUrl);
       this.tabRepository.createTab(request.getValue());
       moveNavigation("right");
       return;
@@ -1276,8 +1276,10 @@ class CollectionExplorerPage {
         type: aiRequest.getValue().type,
         description: "",
         aiRequest: {
-          aiModelProvider: aiRequest?.getValue().property?.aiRequest?.aiModelProvider,
-          aiModelVariant: aiRequest?.getValue().property?.aiRequest?.aiModelVariant,
+          aiModelProvider:
+            aiRequest?.getValue().property?.aiRequest?.aiModelProvider,
+          aiModelVariant:
+            aiRequest?.getValue().property?.aiRequest?.aiModelVariant,
         } as AiRequestBaseInterface,
       },
     };

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/FolderExplorerPage/FolderExplorerPage.ViewModel.ts
@@ -325,7 +325,7 @@ class FolderExplorerPage {
       totalSocketIo,
       totalWebSocket,
       totalMockRequests,
-      totalAiRequests
+      totalAiRequests,
     };
   };
 
@@ -505,7 +505,7 @@ class FolderExplorerPage {
           description: "",
           mockRequest: {
             method: sampleRequest.getValue().property.mockRequest?.method,
-            url: collection?.mockCollectionUrl,
+            url: "",
           },
         },
       },
@@ -575,7 +575,7 @@ class FolderExplorerPage {
         folderId: explorer.id,
       });
       sampleRequest.updateIsSave(true);
-      sampleRequest.updateUrl(collection?.mockCollectionUrl);
+      // sampleRequest.updateUrl(collection?.mockCollectionUrl);
       this.tabRepository.createTab(sampleRequest.getValue());
 
       moveNavigation("right");
@@ -928,7 +928,7 @@ class FolderExplorerPage {
     }
   };
 
-   /**
+  /**
    * Handles creating a new request in a folder
    * @param workspaceId :string
    * @param collection :CollectionDocument - the collection in which new request is going to be created
@@ -968,8 +968,10 @@ class FolderExplorerPage {
           type: aiRequest.getValue().type,
           description: "",
           aiRequest: {
-            aiModelProvider: aiRequest.getValue().property.aiRequest?.aiModelProvider,
-            aiModelVariant: aiRequest.getValue().property.aiRequest?.aiModelVariant,
+            aiModelProvider:
+              aiRequest.getValue().property.aiRequest?.aiModelProvider,
+            aiModelVariant:
+              aiRequest.getValue().property.aiRequest?.aiModelVariant,
           },
         },
       },


### PR DESCRIPTION
### Description
When creating mock request from collection page and folder page, base url was coming in path url part. 

Removed saving the mock base url in mock request url and replace it with empty string. 

![Uploading image.png…]()


### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.