### PR TITLE
fix: added value length check in editort for window style space [SPRW-1622]

### DIFF
--- a/packages/@sparrow-library/src/forms/editor/Editor.svelte
+++ b/packages/@sparrow-library/src/forms/editor/Editor.svelte
@@ -293,6 +293,11 @@
       highlightActiveLine,
       highlightActiveLineGutter,
     };
+    console.log(
+      "Initializing CodeMirror editor with value:",
+      value,
+      value.length,
+    );
 
     let extensions: Extension[];
     extensions = [
@@ -310,11 +315,16 @@
       CreatePlaceHolder(placeholder),
     ];
 
+    let sanitizedValue = value?.includes("\r\n")
+      ? value.replace(/\r\n/g, "\n")
+      : value;
+    console.log("Trimmed value length:", sanitizedValue.length);
+
     let state = EditorState.create({
       doc: value,
       extensions: extensions,
       selection: autofocus
-        ? { anchor: value.length, head: value.length }
+        ? { anchor: sanitizedValue.length, head: sanitizedValue.length }
         : { anchor: 0, head: 0 },
     });
 
@@ -368,6 +378,10 @@
   afterUpdate(() => {
     // Handling the mergeview state while component state changes
     if (!isMergeViewEnabled && value !== codeMirrorView.state.doc.toString()) {
+      let sanitizedValue = value.includes("\r\n")
+        ? value.replace(/\r\n/g, "\n")
+        : value;
+
       codeMirrorView.dispatch({
         changes: {
           from: 0,
@@ -375,7 +389,7 @@
           insert: value,
         },
         selection: autofocus
-          ? { anchor: value.length, head: value.length }
+          ? { anchor: sanitizedValue.length, head: sanitizedValue.length }
           : { anchor: 0, head: 0 },
         annotations: [{ autoChange: true }],
       });

--- a/packages/@sparrow-library/src/forms/editor/Editor.svelte
+++ b/packages/@sparrow-library/src/forms/editor/Editor.svelte
@@ -293,11 +293,6 @@
       highlightActiveLine,
       highlightActiveLineGutter,
     };
-    console.log(
-      "Initializing CodeMirror editor with value:",
-      value,
-      value.length,
-    );
 
     let extensions: Extension[];
     extensions = [
@@ -318,7 +313,6 @@
     let sanitizedValue = value?.includes("\r\n")
       ? value.replace(/\r\n/g, "\n")
       : value;
-    console.log("Trimmed value length:", sanitizedValue.length);
 
     let state = EditorState.create({
       doc: value,
@@ -378,7 +372,7 @@
   afterUpdate(() => {
     // Handling the mergeview state while component state changes
     if (!isMergeViewEnabled && value !== codeMirrorView.state.doc.toString()) {
-      let sanitizedValue = value.includes("\r\n")
+      let sanitizedValue = value?.includes("\r\n")
         ? value.replace(/\r\n/g, "\n")
         : value;
 

--- a/packages/@sparrow-library/src/forms/editor/Editor.svelte
+++ b/packages/@sparrow-library/src/forms/editor/Editor.svelte
@@ -310,6 +310,7 @@
       CreatePlaceHolder(placeholder),
     ];
 
+    // Removing window style space(\r\n) to find correct cursor position
     let sanitizedValue = value?.includes("\r\n")
       ? value.replace(/\r\n/g, "\n")
       : value;


### PR DESCRIPTION
App was freezing when a request body has window style space(\r\n) as body length was coming different when compared to it's beautified. 
To resolve this added a check to remove window style space from string. 

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.