### PR TITLE
fix: SPRW-1267-left-panel-workspace-name-has-space-but-its-being-truncated-to-early 

### DIFF
--- a/packages/@sparrow-workspaces/src/features/workspace-actions/layout/WorkspaceActions.svelte
+++ b/packages/@sparrow-workspaces/src/features/workspace-actions/layout/WorkspaceActions.svelte
@@ -739,7 +739,7 @@
           </span>
           <span
             class="ms-2 text-ds-font-size-12 text-ds-font-weight-semi-bold text-truncate"
-            style="max-width: 110px;"
+            style="max-width: 75%;"
           >
             {currentWorkspaceName}
           </span>


### PR DESCRIPTION
### Description
fix: SPRW-1267-left-panel-workspace-name-has-space-but-its-being-truncated-to-early 

### Add Issue Number
Fixes #1267 SPRW

### Add Screenshots/GIFs
If applicable, add a relevant screenshot/GIF here.

### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.