### PR TITLE
fix: debian apt warning for codename stable

### DIFF
--- a/.github/workflows/sparrow-app-prod.yaml
+++ b/.github/workflows/sparrow-app-prod.yaml
@@ -620,6 +620,20 @@ jobs:
           dpkg-scanpackages --arch amd64 pool/ > dists/stable/main/binary-amd64/Packages
           gzip -k dists/stable/main/binary-amd64/Packages
 
+      - name: Create apt-release.conf
+        run: |
+          cat > apt-repo/apt-release.conf <<EOF
+          APT::FTPArchive::Release {
+            Origin "Sparrow";
+            Label "Sparrow";
+            Suite "stable";
+            Codename "stable";
+            Architectures "amd64";
+            Components "main";
+            Description "Sparrow Debian Repository";
+          };
+          EOF
+
       - name: Generate Release file
         run: |
           cd apt-repo


### PR DESCRIPTION
### Description
This PR fixes the codename warning while updating sparrow debian repo.

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.