### PR TITLE
fix: SPRW-1267-left-panel-workspace-name-has-space-but-its-being-truncated-to-early

### DIFF
--- a/packages/@sparrow-workspaces/src/features/workspace-actions/layout/WorkspaceActions.svelte
+++ b/packages/@sparrow-workspaces/src/features/workspace-actions/layout/WorkspaceActions.svelte
@@ -733,13 +733,16 @@
           }
         }}
       >
-        <div class="d-flex flex-row align-items-center flex-grow-1">
+        <div
+          class="d-flex flex-row align-items-center flex-grow-1"
+          style="width:100%;"
+        >
           <span style="display: flex; margin-left:5px;">
             <WorkspaceRegular size="16px" color="var(--text-ds-neutral-50)" />
           </span>
           <span
             class="ms-2 text-ds-font-size-12 text-ds-font-weight-semi-bold text-truncate"
-            style="max-width: 75%;"
+            style="max-width:75%;"
           >
             {currentWorkspaceName}
           </span>


### PR DESCRIPTION
### Description
Truncation issue in the workspace name

### Add Issue Number
Fixes #3543 
<img width="1920" height="1080" alt="Screenshot from 2025-07-31 16-26-37" src="https://github.com/user-attachments/assets/ae34bea4-d62a-4f1a-b359-bb775487caed" />


### Add Screenshots/GIFs
If applicable, add a relevant screenshot/GIF here.

### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.