### PR TITLE
fix: Global search not opening left panel issue SPRW-160.

### DIFF
--- a/apps/@sparrow-desktop/src/pages/dashboard-page/Dashboard.svelte
+++ b/apps/@sparrow-desktop/src/pages/dashboard-page/Dashboard.svelte
@@ -50,6 +50,12 @@
   import { ResponseMessage, TeamRole } from "@sparrow/common/enums";
   import { planInfoByRole } from "@sparrow/common/utils";
   import { planBannerisOpen, shouldRunThrottled } from "@sparrow/common/store";
+  import {
+    addCollectionItem,
+    isExpandCollection,
+    isExpandEnvironment,
+    isExpandTestflow,
+  } from "@sparrow/workspaces/stores";
 
   const _viewModel = new DashboardViewModel();
   const osDetector = new OSDetector();
@@ -434,6 +440,9 @@
         folderId,
         tree,
       );
+      isExpandCollection.set(true);
+      addCollectionItem(collectionId, "collection");
+      addCollectionItem(folderId, "folder");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -464,6 +473,8 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateCollectionTab(workspaceId, collection);
+      isExpandCollection.set(true);
+      addCollectionItem(collection.id, "collection");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -496,6 +507,9 @@
         collectionId,
         folder,
       );
+      isExpandCollection.set(true);
+      addCollectionItem(collectionId, "collection");
+      addCollectionItem(folder.id, "folder");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -552,6 +566,7 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateEnvironmentTab(environment);
+      isExpandEnvironment.set(true);
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -583,6 +598,7 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateTestflowTab(testflow);
+      isExpandTestflow.set(true);
       if (isActiveWorkspace) {
         navigate("collections");
       }

--- a/apps/@sparrow-web/src/pages/Dashboard/Dashboard.svelte
+++ b/apps/@sparrow-web/src/pages/Dashboard/Dashboard.svelte
@@ -44,6 +44,12 @@
   import MarketplacePage from "../marketplace-page/MarketplacePage.svelte";
   import { ResponseMessage, TeamRole } from "@sparrow/common/enums";
   import { planBannerisOpen, shouldRunThrottled } from "@sparrow/common/store";
+  import {
+    addCollectionItem,
+    isExpandCollection,
+    isExpandEnvironment,
+    isExpandTestflow,
+  } from "../../../../../packages/@sparrow-workspaces/src/stores/recent-left-panel";
 
   const _viewModel = new DashboardViewModel();
   const location = useLocation();
@@ -375,6 +381,9 @@
         folderId,
         tree,
       );
+      isExpandCollection.set(true);
+      addCollectionItem(collectionId, "collection");
+      addCollectionItem(folderId, "folder");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -404,6 +413,8 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateCollectionTab(workspaceId, collection);
+      isExpandCollection.set(true);
+      addCollectionItem(collection.id, "collection");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -435,6 +446,9 @@
         collectionId,
         folder,
       );
+      isExpandCollection.set(true);
+      addCollectionItem(collectionId, "collection");
+      addCollectionItem(folder.id, "folder");
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -489,6 +503,7 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateEnvironmentTab(environment);
+      isExpandEnvironment.set(true);
       if (isActiveWorkspace) {
         navigate("collections");
       }
@@ -519,6 +534,7 @@
       }
       await _viewModel.setOpenTeam(workspaceData.toMutableJSON().team?.teamId);
       await _viewModel.switchAndCreateTestflowTab(testflow);
+      isExpandTestflow.set(true);
       if (isActiveWorkspace) {
         navigate("collections");
       }


### PR DESCRIPTION
### Description
I’ve resolved the issue—now, whenever a user tries to open a collection, request, environment, or test flow from global search, the left panel will also open along with the tab.

### Add Issue Number
Fixes #jira

### Add Screenshots/GIFs
https://github.com/user-attachments/assets/67253ec5-f95e-45d9-bb5b-05dcba7a2a60

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**