### PR TITLE
fix: added team Invites sync through polling SPRW-921.

### DIFF
--- a/apps/@sparrow-desktop/src/pages/teams-page/Teams.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/teams-page/Teams.ViewModel.ts
@@ -405,6 +405,17 @@ export class TeamsViewModel {
     }
   };
 
+  public constructBaseUrl = async (_teamId: string) => {
+    const teamData = await this.teamRepository.getTeamDoc(_teamId);
+    const hubUrl = teamData?.hubUrl;
+
+    if (hubUrl && constants.APP_ENVIRONMENT_PATH !== "local") {
+      const envSuffix = constants.APP_ENVIRONMENT_PATH;
+      return `${hubUrl}/${envSuffix}`;
+    }
+    return constants.API_URL;
+  };
+
   public getUserTrialExhaustedStatus = async (): Promise<boolean> => {
     const response = await this.guestUserRepository.findOne({
       name: "guestUser",
@@ -430,5 +441,13 @@ export class TeamsViewModel {
       constants.ADMIN_URL +
       `?accessToken=${accessToken}&refreshToken=${refreshToken}&email=${email}&source=desktop&trial=login_trial`;
     open(url);
+  };
+
+  public teamLatestTimestamps = async (teamId: string) => {
+    const baseUrl = await this.constructBaseUrl(teamId);
+    const response = await this.teamService.teamTimestamps(teamId, baseUrl);
+    if (response.isSuccessful) {
+      return response.data;
+    }
   };
 }

--- a/apps/@sparrow-desktop/src/services/team.service.ts
+++ b/apps/@sparrow-desktop/src/services/team.service.ts
@@ -207,4 +207,15 @@ export class TeamService {
     );
     return response;
   };
+
+  public teamTimestamps = async (teamId: string, baseUrl: string) => {
+    const response = await makeRequest(
+      "GET",
+      `${baseUrl}/api/team/${teamId}/updates`,
+      {
+        headers: getAuthHeaders(),
+      },
+    );
+    return response;
+  };
 }

--- a/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/Teams/Teams.ViewModel.ts
@@ -486,6 +486,17 @@ export class TeamsViewModel {
     }
   };
 
+  public constructBaseUrl = async (_teamId: string) => {
+    const teamData = await this.teamRepository.getTeamDoc(_teamId);
+    const hubUrl = teamData?.hubUrl;
+
+    if (hubUrl && constants.APP_ENVIRONMENT_PATH !== "local") {
+      const envSuffix = constants.APP_ENVIRONMENT_PATH;
+      return `${hubUrl}/${envSuffix}`;
+    }
+    return constants.API_URL;
+  };
+
   public handleStartTrial = () => {
     debugger;
     const email = getClientUser().email;
@@ -495,5 +506,13 @@ export class TeamsViewModel {
       constants.ADMIN_URL +
       `?accessToken=${accessToken}&refreshToken=${refreshToken}&email=${email}&source=web&trial=login_trial`;
     window.open(url, "_blank");
+  };
+
+  public teamLatestTimestamps = async (teamId: string) => {
+    const baseUrl = await this.constructBaseUrl(teamId);
+    const response = await this.teamService.teamTimestamps(teamId, baseUrl);
+    if (response.isSuccessful) {
+      return response.data;
+    }
   };
 }

--- a/apps/@sparrow-web/src/services/team.service.ts
+++ b/apps/@sparrow-web/src/services/team.service.ts
@@ -208,4 +208,15 @@ export class TeamService {
     );
     return response;
   };
+
+  public teamTimestamps = async (teamId: string, baseUrl: string) => {
+    const response = await makeRequest(
+      "GET",
+      `${baseUrl}/api/team/${teamId}/updates`,
+      {
+        headers: getAuthHeaders(),
+      },
+    );
+    return response;
+  };
 }


### PR DESCRIPTION
### Description
I've added a check for team updates—whenever the team is updated, we trigger a refresh to reflect the changes. The timing of the team update call adjusts based on how long the user spends on the Teams page.

### Add Issue Number
Fixes #jira

### Add Screenshots/GIFs
https://github.com/user-attachments/assets/ae3b7edc-5e18-4c92-b524-72afc30674e4

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**