### PR TITLE
fix: generate variable undo issue SPRW-1652. 

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -218,20 +218,19 @@ export class EnvironmentExplorerViewModel {
         if (foundIndex !== -1) {
           const foundObject =
             progressiveTab.property.environment.aiVariable[foundIndex];
-          // ✅ Remove id and undo
-          const { id, undo, ...cleanedObject } = foundObject;
+          // ✅ Keep id and undo (no destructuring removal)
           const currentPairs =
             progressiveTab.property?.environment?.variable || [];
           const updatedPairs = [...currentPairs];
           if (updatedPairs.length > 0) {
             updatedPairs.splice(updatedPairs.length - 1, 0, {
-              ...cleanedObject,
+              ...foundObject,
               type: "ai-generated",
               lifespan: "short",
             });
           } else {
             updatedPairs.push({
-              ...cleanedObject,
+              ...foundObject,
               type: "ai-generated",
               lifespan: "short",
             });
@@ -274,15 +273,12 @@ export class EnvironmentExplorerViewModel {
       ) {
         progressiveTab.property.environment.variable.pop();
       }
-      // Map aiVariable, removing id and undo
       const sanitizedAiVariables =
-        progressiveTab.property.environment.aiVariable.map(
-          ({ id, undo, ...rest }) => ({
-            ...rest,
-            type: "ai-generated",
-            lifespan: "short",
-          }),
-        );
+        progressiveTab.property.environment.aiVariable.map((variable) => ({
+          ...variable,
+          type: "ai-generated",
+          lifespan: "short",
+        }));
       await this.updateVariables([
         ...progressiveTab.property.environment.variable,
         ...sanitizedAiVariables,
@@ -329,8 +325,6 @@ export class EnvironmentExplorerViewModel {
       }
     }else if (type === "revert-all") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
-      // Remove the last item from environment.variable
-
       const aiVariable = [];
       const userVariable = [];
       progressiveTab.property?.environment?.variable.forEach((variable)=>{

--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -107,7 +107,7 @@ export class EnvironmentExplorerViewModel {
     let environmentServer = await this.environmentRepository.readEnvironment(
       progressiveTab.id,
     );
-    
+
     if (!environmentServer) {
       result = false;
     }
@@ -211,6 +211,7 @@ export class EnvironmentExplorerViewModel {
     if (type === "accept" && typeof index === "number") {
       try {
         const progressiveTab = createDeepCopy(this._tab.getValue());
+        progressiveTab;
         const foundIndex =
           progressiveTab.property.environment.aiVariable.findIndex(
             (_, i) => i === index,
@@ -218,7 +219,6 @@ export class EnvironmentExplorerViewModel {
         if (foundIndex !== -1) {
           const foundObject =
             progressiveTab.property.environment.aiVariable[foundIndex];
-          // ✅ Keep id and undo (no destructuring removal)
           const currentPairs =
             progressiveTab.property?.environment?.variable || [];
           const updatedPairs = [...currentPairs];

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -217,20 +217,19 @@ export class EnvironmentExplorerViewModel {
         if (foundIndex !== -1) {
           const foundObject =
             progressiveTab.property.environment.aiVariable[foundIndex];
-          // ✅ Remove id and undo
-          const { id, undo, ...cleanedObject } = foundObject;
+          // ✅ Keep id and undo (no destructuring removal)
           const currentPairs =
             progressiveTab.property?.environment?.variable || [];
           const updatedPairs = [...currentPairs];
           if (updatedPairs.length > 0) {
             updatedPairs.splice(updatedPairs.length - 1, 0, {
-              ...cleanedObject,
+              ...foundObject,
               type: "ai-generated",
               lifespan: "short",
             });
           } else {
             updatedPairs.push({
-              ...cleanedObject,
+              ...foundObject,
               type: "ai-generated",
               lifespan: "short",
             });
@@ -273,15 +272,12 @@ export class EnvironmentExplorerViewModel {
       ) {
         progressiveTab.property.environment.variable.pop();
       }
-      // Map aiVariable, removing id and undo
       const sanitizedAiVariables =
-        progressiveTab.property.environment.aiVariable.map(
-          ({ id, undo, ...rest }) => ({
-            ...rest,
-            type: "ai-generated",
-            lifespan: "short",
-          }),
-        );
+        progressiveTab.property.environment.aiVariable.map((variable) => ({
+          ...variable,
+          type: "ai-generated",
+          lifespan: "short",
+        }));
       await this.updateVariables([
         ...progressiveTab.property.environment.variable,
         ...sanitizedAiVariables,
@@ -357,7 +353,7 @@ export class EnvironmentExplorerViewModel {
   };
 
 
-private updatedRequestInCollection(
+  private updatedRequestInCollection(
 
     generatedVariables: any[],
     requestItem: any,
@@ -558,14 +554,14 @@ private updatedRequestInCollection(
           const tabRxDocs = await this.tabRepository.getTabsByCollectionId(progressiveTab?.property?.environment?.generateProperty.collectionId);
           const tabsJson = tabRxDocs.map((doc) => doc.toMutableJSON()).filter((doc)=>{
             if(doc.type === TabTypeEnum.REQUEST || doc.type === TabTypeEnum.WEB_SOCKET || doc.type === TabTypeEnum.GRAPHQL || doc.type === TabTypeEnum.SOCKET_IO){
-              return true;
+                return true;
             }else{
-              return false;
-            }
+                return false;
+              }
           }).map((doc)=>{
              doc.property = this.updatedRequestInCollection(uniqueAiGeneratedVariables, doc.property );
-             return doc;
-          });
+              return doc;
+            });
 
           this.tabRepository.bulkUpsertTabs(tabsJson);
 

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -11,7 +11,10 @@ import { GuideRepository } from "../../../../repositories/guide.repository";
 import { GuestUserRepository } from "../../../../repositories/guest-user.repository";
 import { TabRepository } from "../../../../repositories/tab.repository";
 import { Debounce, CompareArray } from "@sparrow/common/utils";
-import { TabPersistenceTypeEnum, TabTypeEnum } from "@sparrow/common/types/workspace/tab";
+import {
+  TabPersistenceTypeEnum,
+  TabTypeEnum,
+} from "@sparrow/common/types/workspace/tab";
 import { CollectionService } from "src/services/collection.service";
 import constants from "src/constants/constants";
 import { CollectionRepository } from "src/repositories/collection.repository";
@@ -292,63 +295,57 @@ export class EnvironmentExplorerViewModel {
       await this.updateGeneratedVariables([]);
     } else if (type === "revert" && typeof index === "number") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
-        const foundIndex =
-          progressiveTab.property.environment.variable.findIndex(
-            (_, i) => i === index,
-          );
-        if (foundIndex !== -1) {
-          const foundObject =
-            progressiveTab.property.environment.variable[foundIndex];
-          const currentPairs =
-            progressiveTab.property?.environment?.aiVariable || [];
-          const updatedPairs = [...currentPairs];
-          if (updatedPairs.length > 0) {
-            updatedPairs.splice(updatedPairs.length - 1, 0, {
-              ...foundObject,
-               type: "user-generated",
-               lifespan: "long",
-            });
-          } else {
-            updatedPairs.push({
-              ...foundObject,
-               type: "user-generated",
-               lifespan: "long",
-            });
-          }
-          const remainingVariables =
-            progressiveTab.property.environment.variable.filter(
-              (_, i) => i !== foundIndex,
-            );
-          await this.updateVariables(remainingVariables);
-          await this.updateGeneratedVariables(updatedPairs);
-          await this.updateEnvironmentAiVariableGenerationStatus("generated");
+      const foundIndex = progressiveTab.property.environment.variable.findIndex(
+        (_, i) => i === index,
+      );
+      if (foundIndex !== -1) {
+        const foundObject =
+          progressiveTab.property.environment.variable[foundIndex];
+        const currentPairs =
+          progressiveTab.property?.environment?.aiVariable || [];
+        const updatedPairs = [...currentPairs];
+        if (updatedPairs.length > 0) {
+          updatedPairs.splice(updatedPairs.length - 1, 0, {
+            ...foundObject,
+            type: "user-generated",
+            lifespan: "long",
+          });
+        } else {
+          updatedPairs.push({
+            ...foundObject,
+            type: "user-generated",
+            lifespan: "long",
+          });
         }
         const remainingVariables =
           progressiveTab.property.environment.variable.filter(
             (_, i) => i !== foundIndex,
           );
-        this.updateVariables(remainingVariables);
-        this.updateGeneratedVariables(updatedPairs);
+        await this.updateVariables(remainingVariables);
+        await this.updateGeneratedVariables(updatedPairs);
         await this.updateEnvironmentAiVariableGenerationStatus("generated");
       }
-    }else if (type === "revert-all") {
+    } else if (type === "revert-all") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
       const aiVariable = [];
       const userVariable = [];
-      progressiveTab.property?.environment?.variable.forEach((variable)=>{
-          if(variable.lifespan === "short"){
+      progressiveTab.property?.environment?.variable.forEach((variable) => {
+        if (variable.lifespan === "short") {
           aiVariable.push({
             ...variable,
             type: "user-generated",
             lifespan: "long",
           });
-          }else{
+        } else {
           userVariable.push(variable);
         }
       });
 
       await this.updateVariables([...userVariable]);
-      await this.updateGeneratedVariables([...progressiveTab.property?.environment?.aiVariable, ...aiVariable]);
+      await this.updateGeneratedVariables([
+        ...progressiveTab.property?.environment?.aiVariable,
+        ...aiVariable,
+      ]);
       await this.updateEnvironmentAiVariableGenerationStatus("generated");
     }
   };
@@ -361,9 +358,7 @@ export class EnvironmentExplorerViewModel {
     return;
   };
 
-
   private updatedRequestInCollection(
-
     generatedVariables: any[],
     requestItem: any,
   ): any {
@@ -559,16 +554,29 @@ export class EnvironmentExplorerViewModel {
             insertGenerateVariableResponse.data.data,
           );
 
-
-          const tabRxDocs = await this.tabRepository.getTabsByCollectionId(progressiveTab?.property?.environment?.generateProperty.collectionId);
-          const tabsJson = tabRxDocs.map((doc) => doc.toMutableJSON()).filter((doc)=>{
-            if(doc.type === TabTypeEnum.REQUEST || doc.type === TabTypeEnum.WEB_SOCKET || doc.type === TabTypeEnum.GRAPHQL || doc.type === TabTypeEnum.SOCKET_IO){
+          const tabRxDocs = await this.tabRepository.getTabsByCollectionId(
+            progressiveTab?.property?.environment?.generateProperty
+              .collectionId,
+          );
+          const tabsJson = tabRxDocs
+            .map((doc) => doc.toMutableJSON())
+            .filter((doc) => {
+              if (
+                doc.type === TabTypeEnum.REQUEST ||
+                doc.type === TabTypeEnum.WEB_SOCKET ||
+                doc.type === TabTypeEnum.GRAPHQL ||
+                doc.type === TabTypeEnum.SOCKET_IO
+              ) {
                 return true;
-            }else{
+              } else {
                 return false;
               }
-          }).map((doc)=>{
-             doc.property = this.updatedRequestInCollection(uniqueAiGeneratedVariables, doc.property );
+            })
+            .map((doc) => {
+              doc.property = this.updatedRequestInCollection(
+                uniqueAiGeneratedVariables,
+                doc.property,
+              );
               return doc;
             });
 

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -213,6 +213,7 @@ export class EnvironmentExplorerViewModel {
     if (type === "accept" && typeof index === "number") {
       try {
         const progressiveTab = createDeepCopy(this._tab.getValue());
+        progressiveTab;
         const foundIndex =
           progressiveTab.property.environment.aiVariable.findIndex(
             (_, i) => i === index,
@@ -220,7 +221,6 @@ export class EnvironmentExplorerViewModel {
         if (foundIndex !== -1) {
           const foundObject =
             progressiveTab.property.environment.aiVariable[foundIndex];
-          // ✅ Keep id and undo (no destructuring removal)
           const currentPairs =
             progressiveTab.property?.environment?.variable || [];
           const updatedPairs = [...currentPairs];

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -181,7 +181,28 @@ export class EnvironmentExplorerViewModel {
     return constants.API_URL;
   };
 
-  public updateVariableSelection = async (type?: string, index?: number) => {
+  private updateUndoStatus(id: string, status: boolean) {
+    const progressiveTab = createDeepCopy(this._tab.getValue());
+    let aiGeneratedVariables =
+      progressiveTab.property.environment.aiVariable || [];
+
+    aiGeneratedVariables = aiGeneratedVariables.map((v: any) => {
+      if (v.id === id) {
+        return {
+          ...v,
+          undo: status,
+        };
+      }
+      return v;
+    });
+
+    this.updateGeneratedVariables(aiGeneratedVariables);
+  }
+
+  public updateVariableSelection = async (
+    type?: string,
+    index?: number | string,
+  ) => {
     if (type === "regenerate") {
       await this.reGenerateVariables();
       return;
@@ -189,7 +210,6 @@ export class EnvironmentExplorerViewModel {
     if (type === "accept" && typeof index === "number") {
       try {
         const progressiveTab = createDeepCopy(this._tab.getValue());
-        progressiveTab;
         const foundIndex =
           progressiveTab.property.environment.aiVariable.findIndex(
             (_, i) => i === index,
@@ -197,18 +217,20 @@ export class EnvironmentExplorerViewModel {
         if (foundIndex !== -1) {
           const foundObject =
             progressiveTab.property.environment.aiVariable[foundIndex];
+          // ✅ Remove id and undo
+          const { id, undo, ...cleanedObject } = foundObject;
           const currentPairs =
             progressiveTab.property?.environment?.variable || [];
           const updatedPairs = [...currentPairs];
           if (updatedPairs.length > 0) {
             updatedPairs.splice(updatedPairs.length - 1, 0, {
-              ...foundObject,
+              ...cleanedObject,
               type: "ai-generated",
               lifespan: "short",
             });
           } else {
             updatedPairs.push({
-              ...foundObject,
+              ...cleanedObject,
               type: "ai-generated",
               lifespan: "short",
             });
@@ -219,7 +241,6 @@ export class EnvironmentExplorerViewModel {
             );
           this.updateGeneratedVariables(remainingGeneratedVariables);
           this.updateVariables(updatedPairs);
-          // console.log()
           if (!remainingGeneratedVariables?.length) {
             await this.updateEnvironmentAiVariableGenerationStatus("accepted");
           }
@@ -227,13 +248,22 @@ export class EnvironmentExplorerViewModel {
       } catch (error) {
         console.error("Error accepting generated variable:", error);
       }
-    } else if (type === "reject" && typeof index === "number") {
+    } else if (type === "undo" && typeof index === "string") {
+      this.updateUndoStatus(index, true);
+    } else if (type === "remove" && typeof index === "string") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
-      const remainingGeneratedVariables =
-        progressiveTab.property.environment.aiVariable;
-      if (remainingGeneratedVariables?.length < 2) {
+      let aiGeneratedVariables =
+        progressiveTab.property.environment.aiVariable || [];
+      if (aiGeneratedVariables?.length < 2) {
         await this.updateEnvironmentAiVariableGenerationStatus("rejected");
       }
+      // remove only the "undo" object with matching id
+      aiGeneratedVariables = aiGeneratedVariables.filter(
+        (v: any) => !(v.id === index && v.undo === true),
+      );
+      this.updateGeneratedVariables(aiGeneratedVariables);
+    } else if (type === "removeUndo" && typeof index === "string") {
+      this.updateUndoStatus(index, false);
     } else if (type === "accept-all") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
       // Remove the last item from environment.variable
@@ -243,13 +273,18 @@ export class EnvironmentExplorerViewModel {
       ) {
         progressiveTab.property.environment.variable.pop();
       }
+      // Map aiVariable, removing id and undo
+      const sanitizedAiVariables =
+        progressiveTab.property.environment.aiVariable.map(
+          ({ id, undo, ...rest }) => ({
+            ...rest,
+            type: "ai-generated",
+            lifespan: "short",
+          }),
+        );
       await this.updateVariables([
         ...progressiveTab.property.environment.variable,
-        ...progressiveTab.property.environment.aiVariable.map((item) => ({
-          ...item,
-          type: "ai-generated",
-          lifespan: "short",
-        })),
+        ...sanitizedAiVariables,
         {
           key: "",
           value: "",
@@ -259,54 +294,54 @@ export class EnvironmentExplorerViewModel {
       await this.updateEnvironmentAiVariableGenerationStatus("accepted");
       await this.updateGeneratedVariables([]);
     } else if (type === "revert" && typeof index === "number") {
-        const progressiveTab = createDeepCopy(this._tab.getValue());
+      const progressiveTab = createDeepCopy(this._tab.getValue());
         const foundIndex =
           progressiveTab.property.environment.variable.findIndex(
-            (_, i) => i === index,
-          );
-        if (foundIndex !== -1) {
-          const foundObject =
-            progressiveTab.property.environment.variable[foundIndex];
-          const currentPairs =
-            progressiveTab.property?.environment?.aiVariable || [];
-          const updatedPairs = [...currentPairs];
-          if (updatedPairs.length > 0) {
-            updatedPairs.splice(updatedPairs.length - 1, 0, {
-              ...foundObject,
-               type: "user-generated",
-               lifespan: "long",
-            });
-          } else {
-            updatedPairs.push({
-              ...foundObject,
-               type: "user-generated",
-               lifespan: "long",
-            });
-          }
-          const remainingVariables =
-            progressiveTab.property.environment.variable.filter(
-              (_, i) => i !== foundIndex,
-            );
-          this.updateVariables(remainingVariables);
-          this.updateGeneratedVariables(updatedPairs);
-          await this.updateEnvironmentAiVariableGenerationStatus("generated");
+        (_, i) => i === index,
+      );
+      if (foundIndex !== -1) {
+        const foundObject =
+          progressiveTab.property.environment.variable[foundIndex];
+        const currentPairs =
+          progressiveTab.property?.environment?.aiVariable || [];
+        const updatedPairs = [...currentPairs];
+        if (updatedPairs.length > 0) {
+          updatedPairs.splice(updatedPairs.length - 1, 0, {
+            ...foundObject,
+            type: "user-generated",
+            lifespan: "long",
+          });
+        } else {
+          updatedPairs.push({
+            ...foundObject,
+            type: "user-generated",
+            lifespan: "long",
+          });
         }
+        const remainingVariables =
+          progressiveTab.property.environment.variable.filter(
+            (_, i) => i !== foundIndex,
+          );
+        this.updateVariables(remainingVariables);
+        this.updateGeneratedVariables(updatedPairs);
+        await this.updateEnvironmentAiVariableGenerationStatus("generated");
+      }
     }else if (type === "revert-all") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
       const aiVariable = [];
-      const userVariable = []; 
+      const userVariable = [];
       progressiveTab.property?.environment?.variable.forEach((variable)=>{
           if(variable.lifespan === "short"){
-            aiVariable.push({
-              ...variable,
-               type: "user-generated",
-               lifespan: "long",
-            });
+          aiVariable.push({
+            ...variable,
+            type: "user-generated",
+            lifespan: "long",
+          });
           }else{
-            userVariable.push(variable);
-          }
+          userVariable.push(variable);
+        }
       });
-      
+
       await this.updateVariables([...userVariable]);
       await this.updateGeneratedVariables([...progressiveTab.property?.environment?.aiVariable, ...aiVariable]);
       await this.updateEnvironmentAiVariableGenerationStatus("generated");
@@ -630,10 +665,15 @@ private updatedRequestInCollection(
       if (response?.isSuccessful) {
         await this.updateEnvironmentAiVariableGenerationStatus("generated");
         const generatedData = response?.data?.data || [];
-        if (generatedData.length < 1) {
+        const updatedGeneratedData = generatedData.map((item: any) => ({
+          ...item,
+          id: crypto.randomUUID(),
+          undo: false,
+        }));
+        if (updatedGeneratedData.length < 1) {
           await this.updateEnvironmentAiVariableGenerationStatus("empty");
         }
-        await this.updateGeneratedVariables(generatedData);
+        await this.updateGeneratedVariables(updatedGeneratedData);
       } else {
         await this.updateEnvironmentAiVariableGenerationStatus("rejected");
         notifications.error("Failed to Generate Variables.");
@@ -660,10 +700,15 @@ private updatedRequestInCollection(
     if (response?.isSuccessful) {
       await this.updateEnvironmentAiVariableGenerationStatus("generated");
       const generatedData = response?.data?.data || [];
-      if (generatedData.length < 1) {
+      const updatedGeneratedData = generatedData.map((item: any) => ({
+        ...item,
+        id: crypto.randomUUID(),
+        undo: false,
+      }));
+      if (updatedGeneratedData.length < 1) {
         await this.updateEnvironmentAiVariableGenerationStatus("empty");
       }
-      await this.updateGeneratedVariables(generatedData);
+      await this.updateGeneratedVariables(updatedGeneratedData);
     } else {
       await this.updateEnvironmentAiVariableGenerationStatus("rejected");
       notifications.error("Failed to Generate Variables.");

--- a/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
+++ b/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
@@ -244,7 +244,6 @@
     pairs = filteredKeyValue;
     callback(pairs);
   };
-
 </script>
 
 <div class="mb-0 me-0 w-100 py-0 section-layout">
@@ -445,7 +444,7 @@
                         <button
                           class="generate-action-button accept"
                           on:click|stopPropagation={() => {
-                            onUpdateVariableSelection("revert", element.id);
+                            onUpdateVariableSelection("revert", index);
                           }}
                         >
                           <ArrowHookRegular
@@ -486,7 +485,7 @@
                         <button
                           class="generate-action-button accept"
                           on:click|stopPropagation={() => {
-                            onUpdateVariableSelection("accept", element.id);
+                            onUpdateVariableSelection("accept", index);
                           }}
                         >
                           <CheckMarkIcon

--- a/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
+++ b/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
@@ -41,7 +41,7 @@
    */
   export let disabled = false;
   export let isGeneratedVariable = false;
-  export let onUpdateVariableSelection: (type?: string, index?: number) => void;
+  export let onUpdateVariableSelection: (type?: string, id?: string) => void;
 
   export let isRevertEnabled = false;
 
@@ -49,13 +49,14 @@
   let controller: boolean = false;
   const theme = new TabularInputTheme().build();
 
-  // Undo functionality state
-  let undoTimers: Map<number, NodeJS.Timeout> = new Map();
-  let undoCountdowns: Map<number, number> = new Map();
-  let countdownIntervals: Map<number, NodeJS.Timeout> = new Map();
+  // Undo functionality state - now using IDs instead of indices
+  let undoTimers: Map<string, NodeJS.Timeout> = new Map();
+  let undoCountdowns: Map<string, number> = new Map();
+  let countdownIntervals: Map<string, NodeJS.Timeout> = new Map();
 
   $: {
     if (keyValue) {
+      pairs = keyValue;
       identifySelectAllState();
     }
   }
@@ -70,8 +71,6 @@
    * @description - calculates the select all checkbox state - weather checked or not
    */
   const identifySelectAllState = () => {
-    pairs = [];
-    pairs = keyValue;
     controller = false;
     if (pairs.length > 1) {
       let isUncheckedExist: boolean = false;
@@ -112,84 +111,76 @@
 
   /**
    * @description - start undo countdown for generated variables
-   * @param index - index of the pairs that needs to be marked for deletion
+   * @param id - unique ID of the pairs that needs to be marked for deletion
    */
-  const startUndoCountdown = (index: number): void => {
-    // Mark item for deletion and start countdown
-    pairs[index].aiUndo = true;
-    undoCountdowns.set(index, 10);
-    // Update the pairs to reflect the change
-    pairs = pairs;
+  const startUndoCountdown = (id: string): void => {
+    // Set the undo state using the callback function
+    onUpdateVariableSelection("undo", id);
+    // Start countdown
+    undoCountdowns.set(id, 10);
     // Start countdown interval
     const countdownInterval = setInterval(() => {
-      const currentCount = undoCountdowns.get(index);
+      const currentCount = undoCountdowns.get(id);
       if (currentCount && currentCount > 1) {
-        undoCountdowns.set(index, currentCount - 1);
+        undoCountdowns.set(id, currentCount - 1);
         pairs = pairs;
       } else {
         clearInterval(countdownInterval);
-        countdownIntervals.delete(index);
+        countdownIntervals.delete(id);
       }
     }, 1000);
-    countdownIntervals.set(index, countdownInterval);
+    countdownIntervals.set(id, countdownInterval);
+
     // Set timer for permanent deletion
     const undoTimer = setTimeout(() => {
-      permanentlyDeleteItem(index);
+      permanentlyDeleteItem(id);
     }, 10000);
 
-    undoTimers.set(index, undoTimer);
+    undoTimers.set(id, undoTimer);
   };
 
   /**
    * @description - permanently delete the item after timeout
-   * @param index - index of the pairs that needs to be permanently deleted
+   * @param id - unique ID of the pairs that needs to be permanently deleted
    */
-  const permanentlyDeleteItem = (index: number): void => {
+  const permanentlyDeleteItem = (id: string): void => {
     // Clean up timers and state
-    const timer = undoTimers.get(index);
-    const interval = countdownIntervals.get(index);
+    const timer = undoTimers.get(id);
+    const interval = countdownIntervals.get(id);
     if (timer) {
       clearTimeout(timer);
-      undoTimers.delete(index);
+      undoTimers.delete(id);
     }
     if (interval) {
       clearInterval(interval);
-      countdownIntervals.delete(index);
+      countdownIntervals.delete(id);
     }
-    undoCountdowns.delete(index);
-    // Remove the item permanently
-    let filteredKeyValue = pairs.filter((elem, i) => {
-      if (i !== index) {
-        return true;
-      }
-      return false;
-    });
-    pairs = filteredKeyValue;
-    onUpdateVariableSelection("reject", index);
-    callback(pairs);
+    undoCountdowns.delete(id);
+
+    // Remove the item permanently using the callback
+    onUpdateVariableSelection("remove", id);
   };
 
   /**
    * @description - undo the deletion of a generated variable
-   * @param index - index of the pairs that needs to be restored
+   * @param id - unique ID of the pairs that needs to be restored
    */
-  const undoGeneratedDelete = (index: number): void => {
+  const undoGeneratedDelete = (id: string): void => {
     // Clear the timers
-    const timer = undoTimers.get(index);
-    const interval = countdownIntervals.get(index);
+    const timer = undoTimers.get(id);
+    const interval = countdownIntervals.get(id);
     if (timer) {
       clearTimeout(timer);
-      undoTimers.delete(index);
+      undoTimers.delete(id);
     }
     if (interval) {
       clearInterval(interval);
-      countdownIntervals.delete(index);
+      countdownIntervals.delete(id);
     }
-    undoCountdowns.delete(index);
-    // Restore the item
-    pairs[index].aiUndo = false;
-    pairs = pairs;
-    callback(pairs);
+    undoCountdowns.delete(id);
+
+    // Remove undo state using the callback
+    onUpdateVariableSelection("removeUndo", id);
   };
 
   /**
@@ -199,8 +190,11 @@
   const deletePairs = (index: number): void => {
     if (pairs.length > 1 || isGeneratedVariable) {
       if (isGeneratedVariable) {
-        // For generated variables, start the undo countdown
-        startUndoCountdown(index);
+        // For generated variables, start the undo countdown using the item's ID
+        const itemId = pairs[index].id;
+        if (itemId) {
+          startUndoCountdown(itemId);
+        }
       } else {
         // For regular variables, delete immediately
         let filteredKeyValue = pairs.filter((elem, i) => {
@@ -249,6 +243,8 @@
     pairs = filteredKeyValue;
     callback(pairs);
   };
+
+  $: console.log("this is the ------------------>", keyValue);
 </script>
 
 <div class="mb-0 me-0 w-100 py-0 section-layout">
@@ -278,14 +274,14 @@
           <button
             class="bg-transparent border-0 d-flex text-nowrap common-text align-items-center"
             style="color: var(--text-ds-primary-300);"
-            on:click={onUpdateVariableSelection("accept-all")}
+            on:click={() => onUpdateVariableSelection("accept-all")}
             >Accept All</button
           >
         {:else if isRevertEnabled}
           <button
             class="bg-transparent border-0 d-flex text-nowrap common-text align-items-center"
             style="color: var(--text-ds-neutral-300); text-decoration: underline;"
-            on:click={onUpdateVariableSelection("revert-all")}
+            on:click={() => onUpdateVariableSelection("revert-all")}
             >Revert Changes</button
           >
         {/if}
@@ -321,7 +317,7 @@
 
   <div class="w-100 d-block position-relative">
     {#if pairs}
-      {#each pairs as element, index}
+      {#each pairs as element, index (element.id || `fallback-${index}`)}
         <div
           aria-label="Toggle Hover"
           class="w-100 {element.key
@@ -390,7 +386,7 @@
                       onUpdateInput={() => {
                         updatePairs(index);
                       }}
-                      disabled={disabled || element.aiUndo}
+                      disabled={disabled || element.undo}
                       placeholder={"Add Variable"}
                       {theme}
                       enableEnvironmentHighlighting={false}
@@ -410,7 +406,7 @@
                       onUpdateInput={() => {
                         updatePairs(index);
                       }}
-                      disabled={disabled || element.aiUndo}
+                      disabled={disabled || element.undo}
                       placeholder={"Add Value"}
                       {theme}
                       enableEnvironmentHighlighting={false}
@@ -449,7 +445,7 @@
                         <button
                           class="generate-action-button accept"
                           on:click|stopPropagation={() => {
-                            onUpdateVariableSelection("revert", index);
+                            onUpdateVariableSelection("revert", element.id);
                           }}
                         >
                           <ArrowHookRegular
@@ -461,7 +457,7 @@
                     {/if}
                   </span>
                 {:else if isGeneratedVariable}
-                  {#if element?.aiUndo}
+                  {#if element?.undo}
                     <div class="d-flex align-items-center gap-1">
                       <Tooltip
                         title={"Undo delete"}
@@ -471,7 +467,7 @@
                         <button
                           class="generate-action-button undo"
                           on:click|stopPropagation={() =>
-                            undoGeneratedDelete(index)}
+                            undoGeneratedDelete(element.id)}
                         >
                           <ArrowUndoRegular
                             size="12"
@@ -490,7 +486,7 @@
                         <button
                           class="generate-action-button accept"
                           on:click|stopPropagation={() => {
-                            onUpdateVariableSelection("accept", index);
+                            onUpdateVariableSelection("accept", element.id);
                           }}
                         >
                           <CheckMarkIcon

--- a/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
+++ b/packages/@sparrow-workspaces/src/components/tabular-input-v2/TabularInputV2.svelte
@@ -244,7 +244,6 @@
     callback(pairs);
   };
 
-  $: console.log("this is the ------------------>", keyValue);
 </script>
 
 <div class="mb-0 me-0 w-100 py-0 section-layout">


### PR DESCRIPTION
### Description
I’ve resolved the "generate variable undo" issue. The problem occurred due to index changes when items were removed. To fix this, I introduced an undo property and ensured that both undo and id are passed into the keyValuePair. We now identify the correct keyValuePair based on its id.

### Add Issue Number
Fixes #jira

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**