### PR TITLE
fix: restricted the paste functionality in disabled codemirror [SPRW-1040]

### DIFF
--- a/packages/@sparrow-workspaces/src/components/codemirror-input/sub-input/code-mirror-handler/CodeMirrorHandler.svelte
+++ b/packages/@sparrow-workspaces/src/components/codemirror-input/sub-input/code-mirror-handler/CodeMirrorHandler.svelte
@@ -445,7 +445,13 @@
       handleKeyDownChange(event);
     },
 
-    paste: handlePaste, // triggers paste event
+    paste: (event, view: EditorView) => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
+      handlePaste(event);
+    },
   });
 
   /**
@@ -608,6 +614,12 @@
     };
 
     initializeAsync();
+    // Prevent paste if editor is disabled (readonly)
+    codeMirrorEditorDiv.addEventListener("paste", (event) => {
+      if (disabled) {
+        event.preventDefault();
+      }
+    });
   });
 
   afterUpdate(() => {


### PR DESCRIPTION

### Description
In saved responses even if parameters and headers were disabled, user was able to paste data in that. 
Restricted the paste functionality in headers and parameters. 

### Contribution Checklist:
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.