### PR TITLE
fix: generate variable added condition for undo SPRW-1652.

### DIFF
--- a/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -273,12 +273,21 @@ export class EnvironmentExplorerViewModel {
       ) {
         progressiveTab.property.environment.variable.pop();
       }
+
+      // Split aiVariables into undo:true and undo:false
+      const undoAiVariables =
+        progressiveTab.property.environment.aiVariable.filter(
+          (variable) => variable.undo === true,
+        );
+
       const sanitizedAiVariables =
-        progressiveTab.property.environment.aiVariable.map((variable) => ({
-          ...variable,
-          type: "ai-generated",
-          lifespan: "short",
-        }));
+        progressiveTab.property.environment.aiVariable
+          .filter((variable) => !variable.undo)
+          .map((variable) => ({
+            ...variable,
+            type: "ai-generated",
+            lifespan: "short",
+          }));
       await this.updateVariables([
         ...progressiveTab.property.environment.variable,
         ...sanitizedAiVariables,
@@ -289,8 +298,10 @@ export class EnvironmentExplorerViewModel {
           type: "user-generated",
         },
       ]);
-      await this.updateEnvironmentAiVariableGenerationStatus("accepted");
-      await this.updateGeneratedVariables([]);
+      if (undoAiVariables.length < 1) {
+        await this.updateEnvironmentAiVariableGenerationStatus("accepted");
+      }
+      await this.updateGeneratedVariables(undoAiVariables);
     } else if (type === "revert" && typeof index === "number") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
         const foundIndex =

--- a/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
+++ b/apps/@sparrow-web/src/pages/workspace-page/sub-pages/EnvironmentExplorer/EnvironmentExplorerPage.ViewModel.ts
@@ -275,12 +275,20 @@ export class EnvironmentExplorerViewModel {
       ) {
         progressiveTab.property.environment.variable.pop();
       }
+      // Split aiVariables into undo:true and undo:false
+      const undoAiVariables =
+        progressiveTab.property.environment.aiVariable.filter(
+          (variable) => variable.undo === true,
+        );
+
       const sanitizedAiVariables =
-        progressiveTab.property.environment.aiVariable.map((variable) => ({
-          ...variable,
-          type: "ai-generated",
-          lifespan: "short",
-        }));
+        progressiveTab.property.environment.aiVariable
+          .filter((variable) => !variable.undo)
+          .map((variable) => ({
+            ...variable,
+            type: "ai-generated",
+            lifespan: "short",
+          }));
       await this.updateVariables([
         ...progressiveTab.property.environment.variable,
         ...sanitizedAiVariables,
@@ -291,8 +299,10 @@ export class EnvironmentExplorerViewModel {
           type: "user-generated",
         },
       ]);
-      await this.updateEnvironmentAiVariableGenerationStatus("accepted");
-      await this.updateGeneratedVariables([]);
+      if (undoAiVariables.length < 1) {
+        await this.updateEnvironmentAiVariableGenerationStatus("accepted");
+      }
+      await this.updateGeneratedVariables(undoAiVariables);
     } else if (type === "revert" && typeof index === "number") {
       const progressiveTab = createDeepCopy(this._tab.getValue());
       const foundIndex = progressiveTab.property.environment.variable.findIndex(


### PR DESCRIPTION
### Description
I’ve added a condition to handle undo-generated variables. During acceptance, only variables with undo: false will be retained; the rest will continue to be auto-deleted.

### Add Issue Number
Fixes #jira

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**