### PR TITLE
perf: reuse the http client across http requests

### DIFF
--- a/apps/@sparrow-desktop/src-tauri/Cargo.lock
+++ b/apps/@sparrow-desktop/src-tauri/Cargo.lock
@@ -4440,6 +4440,7 @@ dependencies = [
  "native-tls",
  "nfd",
  "objc",
+ "once_cell",
  "regex",
  "reqwest 0.11.27",
  "rust_socketio",

--- a/apps/@sparrow-desktop/src-tauri/Cargo.toml
+++ b/apps/@sparrow-desktop/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ tauri-plugin-shell = "2.3.0"
 tauri-plugin-dialog = "2.3.2"
 tauri-plugin-fs = "2.4.1"
 tauri-plugin-deep-link = "2.4.1"
+once_cell = "1.21.3"
 
 # Windows Specific Dependencies
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
### Description
This PR optimizes API request performance in Sparrow by reusing a single reqwest::Client instance instead of creating a new one for every request.

### Add Screenshots/GIFs


### Add Known Issue
No known issues

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.