### PR TITLE
fix: mock data restrictions during bulk edit of headers and params SPRW-2022.

### DIFF
--- a/packages/@sparrow-workspaces/src/features/rest-explorer/components/request-navigator/RequestNavigator.svelte
+++ b/packages/@sparrow-workspaces/src/features/rest-explorer/components/request-navigator/RequestNavigator.svelte
@@ -13,6 +13,8 @@
   export let isGuestUser: boolean = false;
   export let userRole: any;
   export let isGenerateMockDataModal: boolean = false;
+  export let bulkEditHeadersActive: boolean = false;
+  export let bulkEditParamsActive: boolean = false;
   import { ThreeDotIcon } from "@sparrow/library/assets";
   import { SparkleColoredIcon } from "@sparrow/common/icons";
   import { WorkspaceRole } from "@sparrow/common/enums";
@@ -114,7 +116,7 @@
 </script>
 
 <div style="padding-bottom: 12px; position:relative;">
-  {#if (requestStateSection === RequestSectionEnum.HEADERS || requestStateSection === RequestSectionEnum.PARAMETERS || requestStateSection === RequestSectionEnum.REQUEST_BODY) && !isGuestUser && (userRole === WorkspaceRole.WORKSPACE_ADMIN || userRole === WorkspaceRole.WORKSPACE_EDITOR)}
+  {#if ((requestStateSection === RequestSectionEnum.HEADERS && !bulkEditHeadersActive) || (requestStateSection === RequestSectionEnum.PARAMETERS && !bulkEditParamsActive) || requestStateSection === RequestSectionEnum.REQUEST_BODY) && !isGuestUser && (userRole === WorkspaceRole.WORKSPACE_ADMIN || userRole === WorkspaceRole.WORKSPACE_EDITOR)}
     <div
       class="button-container"
       style="position: absolute; top: 6px; right: 10px;"

--- a/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
@@ -732,6 +732,10 @@
                       bind:isGenerateMockDataModal
                       {isGuestUser}
                       {userRole}
+                      bulkEditHeadersActive={$tab?.property?.request.state
+                        ?.isHeaderBulkEditActive}
+                      bulkEditParamsActive={$tab?.property?.request.state
+                        ?.isParameterBulkEditActive}
                     />
                     <div style="flex:1; overflow:auto;" class="p-0">
                       {#if $requestTabTestDemo}


### PR DESCRIPTION
### Description
I have condition to show the button only when headers or params are in normal mode. 

### Add Issue Number
Fixes #jira

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**