### PR TITLE
fix: assertion tour guide view position issue SPRW-1921.

### DIFF
--- a/packages/@sparrow-workspaces/src/features/request-tab-tour-guide/utils/requestTabScriptCardContent.ts
+++ b/packages/@sparrow-workspaces/src/features/request-tab-tour-guide/utils/requestTabScriptCardContent.ts
@@ -14,7 +14,7 @@ export const RequestTabTestsScriptTourContent = [
     targetId: "request-tab-test",
   },
   {
-    Title: "Add Your First Test!",
+    Title: "Speed Up with Snippets",
     description:
       "No need to start from scratch. Use ready-made snippets to add common tests in just one click.",
     stepCount: 3,

--- a/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
+++ b/packages/@sparrow-workspaces/src/features/rest-explorer/layout/RestExplorer.svelte
@@ -1228,6 +1228,7 @@
                                 requestTabTestDemo.set(true);
                                 isCloseRequestTestDemo(false);
                                 onUpdateResponseState("Tests");
+                                tabsSplitterDirection.set("horizontal");
                                 requestTabTestNoCodeStep.set(1);
                               }}
                               onClose={() => {
@@ -1255,6 +1256,7 @@
                                 onUpdateResponseState("Tests");
                                 isCloseRequestTestScriptDemo(false);
                                 requestTabTestScriptDemo.set(true);
+                                tabsSplitterDirection.set("horizontal");
                                 requestTabTestScriptStep.set(1);
                               }}
                               onClose={() => {


### PR DESCRIPTION
### Description
tout guide should be perform only when tab splits is in horizontal only.

### Add Issue Number
Fixes #jira

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**