### PR TITLE
fix: encode auth token in base64 for Sparrow deep link with backward compatibility [SPRW-3158]

### DIFF
--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -110,9 +110,13 @@
 
   let tokenErrorType = ""; // 'empty', 'invalid', 'format'
   const tokenFormatRegex =
-    /^sparrow:\/\/(invite-login\?)?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
+    /^sparrow:\/\/(invite-login\/?\?)?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
 
   async function tokenValidationLogic() {
+    // FIX malformed URL
+    token = token
+      .replace("invite-login/?", "invite-login?")
+      .replace("sparrow://invite-login/", "sparrow://invite-login");
     // Reset error states
     isTokenErrorMessage = false;
     tokenErrorType = "";

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -118,7 +118,7 @@
 
   let tokenErrorType = ""; // 'empty', 'invalid', 'format'
   const tokenFormatRegex =
-    /^sparrow:\/\/(invite-login\/?\?)?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
+    /^sparrow:\/\/(invite-login\/?\?)?(data=[A-Za-z0-9%+\/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
 
   async function tokenValidationLogic() {
     // FIX malformed URL

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -73,7 +73,7 @@
       await tokenValidationLogic();
     }
 
-    if (initialUrl) {
+    if (initialUrl && !skipAutoLogin) {
       localStorage.removeItem("skipAutoLogin");
     }
 
@@ -95,6 +95,7 @@
   });
 
   const skipLoginHandler = async () => {
+    localStorage.setItem("skipAutoLogin", "true");
     // Save Guest User in local DB
     const response = await _viewModel.findUser({ name: "guestUser" });
     if (!response) {
@@ -144,7 +145,13 @@
     }
 
     // If format is valid, proceed with API validation
-    const params = new URLSearchParams(token.split("?")[1]);
+    let queryString = "";
+
+    if (token.includes("?")) {
+      queryString = token.substring(token.indexOf("?") + 1);
+    }
+
+    const params = new URLSearchParams(queryString);
 
     let accessToken;
     let refreshToken;

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -81,7 +81,7 @@
 
   let tokenErrorType = ""; // 'empty', 'invalid', 'format'
   const tokenFormatRegex =
-    /^sparrow:\/\/\?(?:(?:selfhostBackendUrl=[^&]*&|selfhostAdminUrl=[^&]*&|selfhostWebUrl=[^&]*&){0,3})accessToken=eyJ[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+&refreshToken=eyJ[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+(?:&response=.*?)?&event=login&method=[A-Za-z0-9_-]+\s*$/;
+    /^sparrow:\/\/\?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
 
   async function tokenValidationLogic() {
     // Reset error states
@@ -104,9 +104,31 @@
 
     // If format is valid, proceed with API validation
     const params = new URLSearchParams(token.split("?")[1]);
-    const accessToken = params.get("accessToken");
-    const refreshToken = params.get("refreshToken");
-    const selfhostBackendUrl = params.get("selfhostBackendUrl");
+
+    let accessToken;
+    let refreshToken;
+    let selfhostBackendUrl;
+
+    if (params.get("data")) {
+      // NEW FLOW (base64)
+      try {
+        const decoded = JSON.parse(
+          atob(decodeURIComponent(params.get("data") || "")),
+        );
+        accessToken = decoded.accessToken;
+        refreshToken = decoded.refreshToken;
+        selfhostBackendUrl = decoded.selfhostBackendUrl;
+      } catch (e) {
+        isTokenErrorMessage = true;
+        tokenErrorType = "format";
+        return;
+      }
+    } else {
+      // OLD FLOW (fallback)
+      accessToken = params.get("accessToken");
+      refreshToken = params.get("refreshToken");
+      selfhostBackendUrl = params.get("selfhostBackendUrl");
+    }
     // Additional format validation - check if tokens were extracted properly
     if (!accessToken || !refreshToken) {
       isTokenErrorMessage = true;
@@ -114,7 +136,14 @@
       return;
     }
 
-    const userDetails = jwtDecode(accessToken);
+    let userDetails;
+    try {
+      userDetails = jwtDecode(accessToken);
+    } catch (e) {
+      isTokenErrorMessage = true;
+      tokenErrorType = "invalid";
+      return;
+    }
 
     identifyUser(userDetails.email);
     const apiUrl = constants.API_URL;
@@ -142,7 +171,16 @@
       // Success - clear all errors
       isTokenErrorMessage = false;
       tokenErrorType = "";
-      _viewModel.handleAccountLogin(token);
+      const encodedData = params.get("data");
+      if (encodedData) {
+        const reconstructedToken = `sparrow://?selfhostBackendUrl=${
+          selfhostBackendUrl || ""
+        }&accessToken=${accessToken}&refreshToken=${refreshToken}&event=login&method=email`;
+
+        _viewModel.handleAccountLogin(reconstructedToken);
+      } else {
+        _viewModel.handleAccountLogin(token);
+      }
     } catch (e) {
       // API call failed - invalid or expired token
       isTokenErrorMessage = true;

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -62,8 +62,9 @@
 
     // HANDLE INITIAL OPEN
     const initialUrl = await invoke<string | null>("get_initial_deep_link");
+    const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-    if (initialUrl) {
+    if (initialUrl && !skipAutoLogin) {
       console.log("Initial deep link:", initialUrl);
 
       token = initialUrl;
@@ -72,10 +73,17 @@
       await tokenValidationLogic();
     }
 
+    if (initialUrl) {
+      localStorage.removeItem("skipAutoLogin");
+    }
+
     // HANDLE WHEN APP IS ALREADY OPEN
     await listen("deep-link-urls", async (event: any) => {
+      const skipAutoLogin = localStorage.getItem("skipAutoLogin");
+
+      if (skipAutoLogin) return;
+
       const url = event.payload?.url;
-      console.log("Deep link received:", url);
 
       if (url) {
         token = url;

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -64,34 +64,24 @@
     const initialUrl = await invoke<string | null>("get_initial_deep_link");
     const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-    if (initialUrl) {
+    if (initialUrl && !skipAutoLogin) {
       console.log("Initial deep link:", initialUrl);
 
       token = initialUrl;
       isTokenFormEnabled = true;
 
-      const skipAutoLogin = localStorage.getItem("skipAutoLogin");
-
-      if (skipAutoLogin === "true") {
-        console.log("Skipping auto login (logout case)");
-
-        localStorage.removeItem("skipAutoLogin");
-        return; // 🚨 STOP here
-      }
-
       await tokenValidationLogic();
+    }
+
+    if (initialUrl) {
+      localStorage.removeItem("skipAutoLogin");
     }
 
     // HANDLE WHEN APP IS ALREADY OPEN
     await listen("deep-link-urls", async (event: any) => {
       const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-      if (skipAutoLogin === "true") {
-        console.log("Skipping deep link (listener)");
-
-        localStorage.removeItem("skipAutoLogin");
-        return;
-      }
+      if (skipAutoLogin) return;
 
       const url = event.payload?.url;
 
@@ -105,7 +95,6 @@
   });
 
   const skipLoginHandler = async () => {
-    localStorage.setItem("skipAutoLogin", "true");
     // Save Guest User in local DB
     const response = await _viewModel.findUser({ name: "guestUser" });
     if (!response) {
@@ -155,13 +144,7 @@
     }
 
     // If format is valid, proceed with API validation
-    let queryString = "";
-
-    if (token.includes("?")) {
-      queryString = token.substring(token.indexOf("?") + 1);
-    }
-
-    const params = new URLSearchParams(queryString);
+    const params = new URLSearchParams(token.split("?")[1]);
 
     let accessToken;
     let refreshToken;
@@ -174,19 +157,17 @@
         let decodedString;
 
         try {
-          let normalized = rawData;
+          // Step 1: normalize URL encoding safely
+          let normalized = rawData.replace(/ /g, "+");
 
-          // decode ONLY if encoded
-          if (normalized.includes("%")) {
-            try {
-              normalized = decodeURIComponent(normalized);
-            } catch (e) {}
-          }
+          // Step 2: try full decode (Windows)
+          try {
+            normalized = decodeURIComponent(normalized);
+          } catch (e) {}
 
-          // fix base64 padding
-          const pad = normalized.length % 4;
-          if (pad) {
-            normalized += "=".repeat(4 - pad);
+          // Step 3: ensure proper base64 padding
+          while (normalized.length % 4 !== 0) {
+            normalized += "=";
           }
 
           decodedString = atob(normalized);

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -35,6 +35,7 @@
   import { identifyUser } from "@app/utils/posthog/posthogConfig";
   import { policyConfig } from "@sparrow/common/store";
   import { listen } from "@tauri-apps/api/event";
+  import { invoke } from "@tauri-apps/api/core";
 
   let externalSparrowLink =
     `${constants.SPARROW_AUTH_URL}` + "/init?source=desktop";
@@ -48,29 +49,39 @@
   let os = "";
   onMount(async () => {
     os = await platform();
+
     let navigationPath = "";
     navigationState.subscribe((value) => {
       navigationPath = value;
     });
+
     if (navigationPath === "guestUser") {
       isTokenFormEnabled = true;
       navigationState.set("");
     }
 
-    // HANDLE DEEP LINK AUTO LOGIN
-    await listen("tauri://open-url", async (event: any) => {
-      try {
-        const url = event.payload?.[0];
-        console.log("Deep link received:", url);
+    // HANDLE INITIAL OPEN
+    const initialUrl = await invoke<string | null>("get_initial_deep_link");
 
-        if (url && url.startsWith("sparrow://")) {
-          token = url; // assign token
-          isTokenFormEnabled = true; // optional (shows UI)
+    if (initialUrl) {
+      console.log("Initial deep link:", initialUrl);
 
-          await tokenValidationLogic(); // AUTO LOGIN
-        }
-      } catch (e) {
-        console.error("Deep link handling failed", e);
+      token = initialUrl;
+      isTokenFormEnabled = true;
+
+      await tokenValidationLogic();
+    }
+
+    // HANDLE WHEN APP IS ALREADY OPEN
+    await listen("deep-link-urls", async (event: any) => {
+      const url = event.payload?.url;
+      console.log("Deep link received:", url);
+
+      if (url) {
+        token = url;
+        isTokenFormEnabled = true;
+
+        await tokenValidationLogic();
       }
     });
   });

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -151,11 +151,34 @@
     let selfhostBackendUrl;
 
     if (params.get("data")) {
-      // NEW FLOW (base64)
       try {
-        const decoded = JSON.parse(
-          atob(decodeURIComponent(params.get("data") || "")),
-        );
+        let rawData = params.get("data") || "";
+
+        let decodedString;
+
+        try {
+          // Step 1: normalize URL encoding safely
+          let normalized = rawData.replace(/ /g, "+");
+
+          // Step 2: try full decode (Windows)
+          try {
+            normalized = decodeURIComponent(normalized);
+          } catch (e) {}
+
+          // Step 3: ensure proper base64 padding
+          while (normalized.length % 4 !== 0) {
+            normalized += "=";
+          }
+
+          decodedString = atob(normalized);
+        } catch (e) {
+          isTokenErrorMessage = true;
+          tokenErrorType = "format";
+          return;
+        }
+
+        const decoded = JSON.parse(decodedString);
+
         accessToken = decoded.accessToken;
         refreshToken = decoded.refreshToken;
         selfhostBackendUrl = decoded.selfhostBackendUrl;

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -64,24 +64,25 @@
     const initialUrl = await invoke<string | null>("get_initial_deep_link");
     const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-    if (initialUrl && !skipAutoLogin) {
+    if (initialUrl) {
       console.log("Initial deep link:", initialUrl);
 
       token = initialUrl;
       isTokenFormEnabled = true;
 
-      await tokenValidationLogic();
-    }
-
-    if (initialUrl && !skipAutoLogin) {
+      // ALWAYS clear skip flag BEFORE validation
       localStorage.removeItem("skipAutoLogin");
+
+      await tokenValidationLogic();
     }
 
     // HANDLE WHEN APP IS ALREADY OPEN
     await listen("deep-link-urls", async (event: any) => {
       const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-      if (skipAutoLogin) return;
+      if (skipAutoLogin) {
+        localStorage.removeItem("skipAutoLogin");
+      }
 
       const url = event.payload?.url;
 

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -70,8 +70,14 @@
       token = initialUrl;
       isTokenFormEnabled = true;
 
-      // ALWAYS clear skip flag BEFORE validation
-      localStorage.removeItem("skipAutoLogin");
+      const skipAutoLogin = localStorage.getItem("skipAutoLogin");
+
+      if (skipAutoLogin === "true") {
+        console.log("Skipping auto login (logout case)");
+
+        localStorage.removeItem("skipAutoLogin");
+        return; // 🚨 STOP here
+      }
 
       await tokenValidationLogic();
     }
@@ -80,8 +86,11 @@
     await listen("deep-link-urls", async (event: any) => {
       const skipAutoLogin = localStorage.getItem("skipAutoLogin");
 
-      if (skipAutoLogin) {
+      if (skipAutoLogin === "true") {
+        console.log("Skipping deep link (listener)");
+
         localStorage.removeItem("skipAutoLogin");
+        return;
       }
 
       const url = event.payload?.url;
@@ -165,17 +174,19 @@
         let decodedString;
 
         try {
-          // Step 1: normalize URL encoding safely
-          let normalized = rawData.replace(/ /g, "+");
+          let normalized = rawData;
 
-          // Step 2: try full decode (Windows)
-          try {
-            normalized = decodeURIComponent(normalized);
-          } catch (e) {}
+          // decode ONLY if encoded
+          if (normalized.includes("%")) {
+            try {
+              normalized = decodeURIComponent(normalized);
+            } catch (e) {}
+          }
 
-          // Step 3: ensure proper base64 padding
-          while (normalized.length % 4 !== 0) {
-            normalized += "=";
+          // fix base64 padding
+          const pad = normalized.length % 4;
+          if (pad) {
+            normalized += "=".repeat(4 - pad);
           }
 
           decodedString = atob(normalized);

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -81,7 +81,7 @@
 
   let tokenErrorType = ""; // 'empty', 'invalid', 'format'
   const tokenFormatRegex =
-    /^sparrow:\/\/\?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
+    /^sparrow:\/\/(invite-login\?)?(data=[A-Za-z0-9%+/=]+|.*accessToken=[^&]+&refreshToken=[^&]+)/;
 
   async function tokenValidationLogic() {
     // Reset error states

--- a/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
+++ b/apps/@sparrow-desktop/src/pages/auth-page/Auth.svelte
@@ -34,6 +34,7 @@
   import * as Sentry from "@sentry/svelte";
   import { identifyUser } from "@app/utils/posthog/posthogConfig";
   import { policyConfig } from "@sparrow/common/store";
+  import { listen } from "@tauri-apps/api/event";
 
   let externalSparrowLink =
     `${constants.SPARROW_AUTH_URL}` + "/init?source=desktop";
@@ -55,6 +56,23 @@
       isTokenFormEnabled = true;
       navigationState.set("");
     }
+
+    // HANDLE DEEP LINK AUTO LOGIN
+    await listen("tauri://open-url", async (event: any) => {
+      try {
+        const url = event.payload?.[0];
+        console.log("Deep link received:", url);
+
+        if (url && url.startsWith("sparrow://")) {
+          token = url; // assign token
+          isTokenFormEnabled = true; // optional (shows UI)
+
+          await tokenValidationLogic(); // AUTO LOGIN
+        }
+      } catch (e) {
+        console.error("Deep link handling failed", e);
+      }
+    });
   });
 
   const skipLoginHandler = async () => {

--- a/apps/@sparrow-desktop/src/pages/dashboard-page/Dashboard.ViewModel.ts
+++ b/apps/@sparrow-desktop/src/pages/dashboard-page/Dashboard.ViewModel.ts
@@ -410,6 +410,7 @@ export class DashboardViewModel {
 
   // logout to backend - expires jwt - auth and refresh tokens
   public handleLogout = async (): Promise<boolean> => {
+    localStorage.setItem("skipAutoLogin", "true");
     const response = await userLogout();
     if (response.isSuccessful) {
       await this.clientLogout();


### PR DESCRIPTION
### Description

- Encoded login payload into base64 (data param) for secure and cleaner deep link handling
- Added decoding logic in desktop app with support for both new and legacy token formats
- Maintained existing navigation flow (sparrow://) without changes
- Reconstructed legacy token format internally to ensure compatibility with current login flow

### Add Issue Number
SPRW-3158
### Add Screenshots/GIFs

https://github.com/user-attachments/assets/bf52e195-392d-4f90-b5f3-f6af114acb2f


### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.